### PR TITLE
Fix(posterize): Resolve incorrect vertical tiling/cropping

### DIFF
--- a/src/js/logic/posterize.ts
+++ b/src/js/logic/posterize.ts
@@ -128,16 +128,19 @@ export async function posterize() {
                     const scaleX = targetWidth / tileWidth;
                     const scaleY = targetHeight / tileHeight;
                     const scale = scalingMode === 'fit' ? Math.min(scaleX, scaleY) : Math.max(scaleX, scaleY);
-                    
+
                     const scaledTileWidth = tileWidth * scale;
                     const scaledTileHeight = tileHeight * scale;
 
                     const offsetX = (targetWidth - scaledTileWidth) / 2;
                     const offsetY = (targetHeight - scaledTileHeight) / 2;
-                    
+
+                    const tileRowIndexFromBottom = rows - 1 - r;
+                    const overlapOffset = tileRowIndexFromBottom * overlapInPoints;
+
                     newPage.drawPage(embeddedPage, {
                         x: -c * scaledTileWidth + offsetX - (c * overlapInPoints),
-                        y: r * scaledTileHeight + offsetY - ((rows - 1 - r) * overlapInPoints),
+                        y: -tileRowIndexFromBottom * scaledTileHeight + offsetY + overlapOffset,
                         width: sourceWidth * scale,
                         height: sourceHeight * scale,
                     });


### PR DESCRIPTION
The Y-axis calculation in the `posterize` function was backward for `pdf-lib`'s bottom-left origin, causing the resulting PDF tiles to display only the bottom portion of the content, leaving large empty crops.

Corrected the `y` coordinate calculation using `tileRowIndexFromBottom = rows - 1 - r` to properly map the top-to-bottom loop index to the required bottom-up positioning.

Closes #1 