### PR TITLE
adding unraid template

### DIFF
--- a/unraid_bentopdf.xml
+++ b/unraid_bentopdf.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>bentopdf</Name>
+  <Repository>bentopdf/bentopdf</Repository>
+  <Registry>https://hub.docker.com/r/bentopdf/bentopdf/</Registry>
+  <Network>bridge</Network>
+  <MyIP/>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/alam00000/bentopdf</Support>
+  <Project>https://www.bentopdf.com/</Project>
+  <Overview>Uploaded on behalf of creator: alam00000&#13;
+BentoPDF is a privacy first PDF Toolkit&#13;
+&#13;
+https://hub.docker.com/r/bentopdf/bentopdf/</Overview>
+  <Category>Tools:</Category>
+  <WebUI>http://[IP]:[PORT:80]/</WebUI>
+  <TemplateURL/>
+  <Icon>https://raw.githubusercontent.com/alam00000/bentopdf/refs/heads/main/public/images/favicon.svg</Icon>
+  <ExtraParams/>
+  <PostArgs/>
+  <CPUset/>
+  <DateInstalled>1760606276</DateInstalled>
+  <DonateText/>
+  <DonateLink/>
+  <Requires/>
+  <Config Name="Container Port 1" Target="3000" Default="80" Mode="tcp" Description="" Type="Port" Display="always" Required="false" Mask="false">80</Config>
+  <TailscaleStateDir/>
+</Container>
+


### PR DESCRIPTION
### Description

I have created a template file so that this can he uploaded to the unraid community apps page. Others can also use this template and upload if they please to the dockerman folder of the unraid config folder

Fixes #22 

### Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

There is no change to the docker itself. This template will upload it to the unraid community apps store. This template can be found hosted at: [Bentopdf_template](https://github.com/soultaco83/unraid-templates/tree/master/bentopdf)
If there are any issues or changes to be done let me know.
[bentopdf.xml](https://github.com/user-attachments/files/22945645/bentopdf.xml)
