### PR TITLE
feat(pdf-tools): add attachments feature to embed files in PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # BentoPDF
+
 **BentoPDF** is a powerful, privacy-first, client-side PDF toolkit that allows you to manipulate, edit, merge, and process PDF files directly in your browser. No server-side processing is required, ensuring your files remain secure and private.
 
 ![Docker Pulls](https://img.shields.io/docker/pulls/bentopdf/bentopdf) [![Ko-fi](https://img.shields.io/badge/Buy%20me%20a%20Coffee-yellow?logo=kofi&style=flat-square)](https://ko-fi.com/alio0) ![GitHub Stars](https://img.shields.io/github/stars/alam00000/bentopdf?style=social)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,4 +4,4 @@ services:
     container_name: bentopdf
     restart: unless-stopped
     ports:
-      - "3000:80"
+      - '3000:80'

--- a/src/js/config/pdf-tools.ts
+++ b/src/js/config/pdf-tools.ts
@@ -38,6 +38,7 @@ export const singlePdfLoadTools = [
   'form-filler',
   'posterize',
   'remove-blank-pages',
+  'add-attachments',
 ];
 
 export const simpleTools = [

--- a/src/js/config/tools.ts
+++ b/src/js/config/tools.ts
@@ -283,6 +283,12 @@ export const categories = [
         subtitle: 'Duplicate, reorder, and delete pages.',
       },
       {
+        id: 'add-attachments',
+        name: 'Add Attachments',
+        icon: 'paperclip',
+        subtitle: 'Embed one or more files into your PDF.',
+      },
+      {
         id: 'split',
         name: 'Split PDF',
         icon: 'scissors',
@@ -383,7 +389,7 @@ export const categories = [
         icon: 'ruler-dimension-line',
         subtitle: 'Standardize all pages to a uniform size.',
       },
-      { 
+      {
         id: 'linearize',
         name: 'Linearize PDF',
         icon: 'zap',

--- a/src/js/logic/add-attachments.ts
+++ b/src/js/logic/add-attachments.ts
@@ -1,0 +1,125 @@
+import { showLoader, hideLoader, showAlert } from '../ui';
+import { readFileAsArrayBuffer, downloadFile } from '../utils/helpers';
+import { state } from '../state';
+let attachments: File[] = [];
+
+export async function addAttachments() {
+  if (!state.pdfDoc) {
+    showAlert('Error', 'Main PDF is not loaded.');
+    return;
+  }
+  if (attachments.length === 0) {
+    showAlert('No Files', 'Please select at least one file to attach.');
+    return;
+  }
+
+  showLoader('Embedding files into PDF...');
+  try {
+    const pdfDoc = state.pdfDoc;
+
+    for (let i = 0; i < attachments.length; i++) {
+      const file = attachments[i];
+      showLoader(`Attaching ${file.name} (${i + 1}/${attachments.length})...`);
+
+      const fileBytes = await readFileAsArrayBuffer(file);
+
+      await pdfDoc.attach(fileBytes as ArrayBuffer, file.name, {
+        mimeType: file.type || 'application/octet-stream',
+        description: `Attached file: ${file.name}`,
+        creationDate: new Date(),
+        modificationDate: new Date(file.lastModified),
+      });
+    }
+
+    const pdfBytes = await pdfDoc.save();
+    downloadFile(
+      new Blob([pdfBytes], { type: 'application/pdf' }),
+      `attached-${state.files[0].name}`
+    );
+
+    showAlert(
+      'Success',
+      `${attachments.length} file(s) attached successfully.`
+    );
+  } catch (error: any) {
+    console.error('Error attaching files:', error);
+    showAlert('Error', `Failed to attach files: ${error.message}`);
+  } finally {
+    hideLoader();
+    clearAttachments(); 
+  }
+}
+
+function clearAttachments() {
+  attachments = [];
+  const fileListDiv = document.getElementById('attachment-file-list');
+  const attachmentInput = document.getElementById(
+    'attachment-files-input'
+  ) as HTMLInputElement;
+  const processBtn = document.getElementById(
+    'process-btn'
+  ) as HTMLButtonElement;
+
+  if (fileListDiv) fileListDiv.innerHTML = '';
+  if (attachmentInput) attachmentInput.value = '';
+  if (processBtn) {
+    processBtn.disabled = true;
+    processBtn.classList.add('hidden');
+  }
+}
+
+let isSetup = false; // Prevent duplicate setup
+
+export function setupAddAttachmentsTool() {
+  if (isSetup) return; // Already set up
+  isSetup = true;
+
+  const optionsDiv = document.getElementById('attachment-options');
+  const attachmentInput = document.getElementById(
+    'attachment-files-input'
+  ) as HTMLInputElement;
+  const fileListDiv = document.getElementById('attachment-file-list');
+  const processBtn = document.getElementById(
+    'process-btn'
+  ) as HTMLButtonElement;
+
+  if (!optionsDiv || !attachmentInput || !fileListDiv || !processBtn) {
+    console.error('Attachment tool UI elements not found.');
+    return;
+  }
+
+  optionsDiv.classList.remove('hidden');
+
+  attachmentInput.addEventListener('change', (e) => {
+    const files = (e.target as HTMLInputElement).files;
+    if (files && files.length > 0) {
+      attachments = Array.from(files);
+
+      fileListDiv.innerHTML = '';
+      attachments.forEach((file) => {
+        const div = document.createElement('div');
+        div.className =
+          'flex justify-between items-center p-2 bg-gray-800 rounded-md text-white';
+
+        const nameSpan = document.createElement('span');
+        nameSpan.className = 'truncate text-sm';
+        nameSpan.textContent = file.name; 
+
+        const sizeSpan = document.createElement('span');
+        sizeSpan.className = 'text-xs text-gray-400';
+        sizeSpan.textContent = `${Math.round(file.size / 1024)} KB`;
+
+        div.appendChild(nameSpan);
+        div.appendChild(sizeSpan);
+        fileListDiv.appendChild(div);
+      });
+
+      processBtn.disabled = false;
+      processBtn.classList.remove('hidden');
+    } else {
+      clearAttachments();
+    }
+  });
+
+  processBtn.onclick = addAttachments;
+}

--- a/src/js/logic/add-blank-page.ts
+++ b/src/js/logic/add-blank-page.ts
@@ -8,7 +8,7 @@ export async function addBlankPage() {
   const pageNumberInput = document.getElementById('page-number').value;
   // @ts-expect-error TS(2339) FIXME: Property 'value' does not exist on type 'HTMLEleme... Remove this comment to see the full error message
   const pageCountInput = document.getElementById('page-count').value;
-  
+
   if (pageNumberInput.trim() === '') {
     showAlert('Invalid Input', 'Please enter a page number.');
     return;
@@ -31,7 +31,10 @@ export async function addBlankPage() {
   }
 
   if (isNaN(pageCount) || pageCount < 1) {
-    showAlert('Invalid Input', 'Please enter a valid number of pages (1 or more).');
+    showAlert(
+      'Invalid Input',
+      'Please enter a valid number of pages (1 or more).'
+    );
     return;
   }
 

--- a/src/js/logic/index.ts
+++ b/src/js/logic/index.ts
@@ -62,6 +62,7 @@ import {
 } from './remove-blank-pages.js';
 import { alternateMerge, setupAlternateMergeTool } from './alternate-merge.js';
 import { linearizePdf } from './linearize.js';
+import { addAttachments, setupAddAttachmentsTool } from './add-attachments.js';
 
 export const toolLogic = {
   merge: { process: merge, setup: setupMergeTool },
@@ -130,4 +131,8 @@ export const toolLogic = {
     setup: setupAlternateMergeTool,
   },
   linearize: linearizePdf,
+  'add-attachments': {
+    process: addAttachments,
+    setup: setupAddAttachmentsTool,
+  },
 };

--- a/src/js/logic/linearize.ts
+++ b/src/js/logic/linearize.ts
@@ -30,7 +30,9 @@ async function initializeQpdf() {
 
 export async function linearizePdf() {
   // Check if there are files and at least one PDF
-  const pdfFiles = state.files.filter((file: File) => file.type === 'application/pdf');
+  const pdfFiles = state.files.filter(
+    (file: File) => file.type === 'application/pdf'
+  );
   if (!pdfFiles || pdfFiles.length === 0) {
     showAlert('No PDF Files', 'Please upload at least one PDF file.');
     return;
@@ -43,12 +45,12 @@ export async function linearizePdf() {
   let errorCount = 0;
 
   try {
-    qpdf = await initializeQpdf(); 
+    qpdf = await initializeQpdf();
 
     for (let i = 0; i < pdfFiles.length; i++) {
       const file = pdfFiles[i];
-      const inputPath = `/input_${i}.pdf`; 
-      const outputPath = `/output_${i}.pdf`; 
+      const inputPath = `/input_${i}.pdf`;
+      const outputPath = `/output_${i}.pdf`;
 
       showLoader(`Optimizing ${file.name} (${i + 1}/${pdfFiles.length})...`);
 
@@ -58,23 +60,20 @@ export async function linearizePdf() {
 
         qpdf.FS.writeFile(inputPath, uint8Array);
 
-        const args = [
-          inputPath,
-          '--linearize',
-          outputPath,
-        ];
+        const args = [inputPath, '--linearize', outputPath];
 
         qpdf.callMain(args);
 
         const outputFile = qpdf.FS.readFile(outputPath, { encoding: 'binary' });
-         if (!outputFile || outputFile.length === 0) {
-             console.error(`Linearization resulted in an empty file for ${file.name}.`);
-             throw new Error(`Processing failed for ${file.name}.`);
-         }
+        if (!outputFile || outputFile.length === 0) {
+          console.error(
+            `Linearization resulted in an empty file for ${file.name}.`
+          );
+          throw new Error(`Processing failed for ${file.name}.`);
+        }
 
         zip.file(`linearized-${file.name}`, outputFile, { binary: true });
         successCount++;
-
       } catch (fileError: any) {
         errorCount++;
         console.error(`Failed to linearize ${file.name}:`, fileError);
@@ -91,13 +90,16 @@ export async function linearizePdf() {
             }
           }
         } catch (cleanupError) {
-          console.warn(`Failed to cleanup WASM FS for ${file.name}:`, cleanupError);
+          console.warn(
+            `Failed to cleanup WASM FS for ${file.name}:`,
+            cleanupError
+          );
         }
       }
-    } 
+    }
 
     if (successCount === 0) {
-       throw new Error('No PDF files could be linearized.');
+      throw new Error('No PDF files could be linearized.');
     }
 
     showLoader('Generating ZIP file...');
@@ -109,7 +111,6 @@ export async function linearizePdf() {
       alertMessage += ` ${errorCount} file(s) failed.`;
     }
     showAlert('Processing Complete', alertMessage);
-
   } catch (error: any) {
     console.error('Linearization process error:', error);
     showAlert(

--- a/src/js/ui.ts
+++ b/src/js/ui.ts
@@ -1847,11 +1847,35 @@ export const toolTemplates = {
     </div>
 `,
 
-linearize: () => `
+  linearize: () => `
     <h2 class="text-2xl font-bold text-white mb-4">Linearize PDFs (Fast Web View)</h2>
     <p class="mb-6 text-gray-400">Optimize multiple PDFs for faster loading over the web. Files will be downloaded in a ZIP archive.</p>
     ${createFileInputHTML({ multiple: true, accept: 'application/pdf', showControls: true })} 
     <div id="file-display-area" class="mt-4 space-y-2"></div>
     <button id="process-btn" class="hidden btn-gradient w-full mt-6" disabled>Linearize PDFs & Download ZIP</button> 
+  `,
+  'add-attachments': () => `
+    <h2 class="text-2xl font-bold text-white mb-4">Add Attachments to PDF</h2>
+    <p class="mb-6 text-gray-400">First, upload the PDF document you want to add files to.</p>
+    ${createFileInputHTML({ accept: 'application/pdf' })}
+    <div id="file-display-area" class="mt-4 space-y-2"></div>
+
+    <div id="attachment-options" class="hidden mt-8">
+      <h3 class="text-lg font-semibold text-white mb-3">Upload Files to Attach</h3>
+      <p class="mb-4 text-gray-400">Select one or more files to embed within the PDF. You can attach any file type (images, documents, spreadsheets, etc.).</p>
+      
+      <label for="attachment-files-input" class="w-full flex justify-center items-center px-6 py-10 bg-gray-900 text-gray-400 rounded-lg border-2 border-dashed border-gray-600 hover:bg-gray-800 hover:border-gray-500 cursor-pointer transition-colors">
+        <div class="text-center">
+          <svg class="mx-auto h-12 w-12" stroke="currentColor" fill="none" viewBox="0 0 48 48" aria-hidden="true"><path d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg>
+          <span class="mt-2 block text-sm font-medium">Click to upload files</span>
+          <span class="mt-1 block text-xs">Any file type, multiple files allowed</span>
+        </div>
+        <input id="attachment-files-input" name="attachment-files" type="file" class="sr-only" multiple>
+      </label>
+
+      <div id="attachment-file-list" class="mt-4 space-y-2"></div>
+
+      <button id="process-btn" class="hidden btn-gradient w-full mt-6" disabled>Embed Files & Download</button>
+    </div>
   `,
 };

--- a/src/tests/add-blank-page.test.ts
+++ b/src/tests/add-blank-page.test.ts
@@ -181,7 +181,10 @@ describe('Add Blank Page Tool', () => {
       expect(mockNewDoc.copyPages).toHaveBeenCalledWith(state.pdfDoc, [0, 1]);
       // Should add 1 blank page + 5 existing pages = 6 total calls
       expect(mockNewDoc.addPage).toHaveBeenCalledTimes(6);
-      expect(mockNewDoc.copyPages).toHaveBeenCalledWith(state.pdfDoc, [2, 3, 4]);
+      expect(mockNewDoc.copyPages).toHaveBeenCalledWith(
+        state.pdfDoc,
+        [2, 3, 4]
+      );
       expect(helpers.downloadFile).toHaveBeenCalledWith(
         expect.any(Blob),
         'blank-page-added.pdf'
@@ -196,7 +199,10 @@ describe('Add Blank Page Tool', () => {
 
       await addBlankPage();
 
-      expect(mockNewDoc.copyPages).toHaveBeenCalledWith(state.pdfDoc, [0, 1, 2, 3, 4]);
+      expect(mockNewDoc.copyPages).toHaveBeenCalledWith(
+        state.pdfDoc,
+        [0, 1, 2, 3, 4]
+      );
       // Should add 1 blank page + 5 existing pages = 6 total calls
       expect(mockNewDoc.addPage).toHaveBeenCalledTimes(6);
       // When adding at the end, there are no pages after, so copyPages is not called for indicesAfter
@@ -239,7 +245,10 @@ describe('Add Blank Page Tool', () => {
       expect(mockNewDoc.copyPages).toHaveBeenCalledWith(state.pdfDoc, [0, 1]);
       // Should add 5 blank pages + 5 existing pages = 10 total calls
       expect(mockNewDoc.addPage).toHaveBeenCalledTimes(10);
-      expect(mockNewDoc.copyPages).toHaveBeenCalledWith(state.pdfDoc, [2, 3, 4]);
+      expect(mockNewDoc.copyPages).toHaveBeenCalledWith(
+        state.pdfDoc,
+        [2, 3, 4]
+      );
       expect(helpers.downloadFile).toHaveBeenCalledWith(
         expect.any(Blob),
         'blank-pages-added.pdf'
@@ -255,7 +264,10 @@ describe('Add Blank Page Tool', () => {
       await addBlankPage();
 
       expect(ui.showLoader).toHaveBeenCalledWith('Adding 2 blank pages...');
-      expect(mockNewDoc.copyPages).toHaveBeenCalledWith(state.pdfDoc, [0, 1, 2, 3, 4]);
+      expect(mockNewDoc.copyPages).toHaveBeenCalledWith(
+        state.pdfDoc,
+        [0, 1, 2, 3, 4]
+      );
       // Should add 2 blank pages + 5 existing pages = 7 total calls
       expect(mockNewDoc.addPage).toHaveBeenCalledTimes(7);
       expect(helpers.downloadFile).toHaveBeenCalledWith(
@@ -268,7 +280,9 @@ describe('Add Blank Page Tool', () => {
   // -------------------- Error Handling Tests --------------------
   describe('Error Handling', () => {
     it('should handle PDF creation errors', async () => {
-      vi.mocked(PDFLibDocument.create).mockRejectedValue(new Error('PDF creation failed'));
+      vi.mocked(PDFLibDocument.create).mockRejectedValue(
+        new Error('PDF creation failed')
+      );
 
       document.body.innerHTML = `
         <input id="page-number" value="2" />
@@ -277,7 +291,10 @@ describe('Add Blank Page Tool', () => {
 
       await addBlankPage();
 
-      expect(ui.showAlert).toHaveBeenCalledWith('Error', 'Could not add blank page.');
+      expect(ui.showAlert).toHaveBeenCalledWith(
+        'Error',
+        'Could not add blank page.'
+      );
       expect(ui.hideLoader).toHaveBeenCalled();
     });
 
@@ -291,7 +308,10 @@ describe('Add Blank Page Tool', () => {
 
       await addBlankPage();
 
-      expect(ui.showAlert).toHaveBeenCalledWith('Error', 'Could not add blank page.');
+      expect(ui.showAlert).toHaveBeenCalledWith(
+        'Error',
+        'Could not add blank page.'
+      );
       expect(ui.hideLoader).toHaveBeenCalled();
     });
 
@@ -305,7 +325,10 @@ describe('Add Blank Page Tool', () => {
 
       await addBlankPage();
 
-      expect(ui.showAlert).toHaveBeenCalledWith('Error', 'Could not add blank page.');
+      expect(ui.showAlert).toHaveBeenCalledWith(
+        'Error',
+        'Could not add blank page.'
+      );
       expect(ui.hideLoader).toHaveBeenCalled();
     });
   });

--- a/src/tests/pdf-tools.test.ts
+++ b/src/tests/pdf-tools.test.ts
@@ -19,7 +19,7 @@ describe('Tool Configuration Arrays', () => {
 
     it('should have the correct number of tools', () => {
       // This acts as a snapshot test to catch unexpected additions/removals.
-      expect(singlePdfLoadTools).toHaveLength(39);
+      expect(singlePdfLoadTools).toHaveLength(40);
     });
 
     it('should not contain any duplicate tools', () => {


### PR DESCRIPTION
### Description
Implement new functionality to allow embedding attachments into PDF documents. The feature includes:
- UI for selecting PDF and files to attach
- Logic to embed files while preserving metadata
- Display of attached files with size information
- Download of modified PDF with embedded files

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### 🧪 How Has This Been Tested?

**Checklist:**

- [x] Verified output manually
- [x] Tested with relevant sample documents or data
- [ ] Wrote Vite Test Case (TODO)

**Expected Results:**

- Users should be able to upload a pdf file and attachments to it

**Actual Results:**

- The resutls are as expected

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
