### PR TITLE
Add GHCR publishing support

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -33,6 +33,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract version from tag
         id: version
         run: |
@@ -55,6 +61,9 @@ jobs:
             bentopdf/bentopdf${{ matrix.mode.suffix }}:latest
             bentopdf/bentopdf${{ matrix.mode.suffix }}:${{ steps.version.outputs.version_without_v }}
             bentopdf/bentopdf${{ matrix.mode.suffix }}:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/bentopdf${{ matrix.mode.suffix }}:latest
+            ghcr.io/${{ github.repository_owner }}/bentopdf${{ matrix.mode.suffix }}:${{ steps.version.outputs.version_without_v }}
+            ghcr.io/${{ github.repository_owner }}/bentopdf${{ matrix.mode.suffix }}:${{ steps.version.outputs.version }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -102,13 +102,19 @@ You can run BentoPDF locally for development or personal use.
 
 ### 🚀 Quick Start with Docker
 
-You can run BentoPDF directly from Docker Hub without cloning the repository:
+You can run BentoPDF directly from Docker Hub or GitHub Container Registry without cloning the repository:
 
 You can also watch the video on how to set it up 👉
 [BentoPDF Docker Setup](https://drive.google.com/file/d/1C4eJ2nqeaH__1Tlad-xuBHaF2Ha4fSBf/view?usp=drive_link)
 
+**Using Docker Hub:**
 ```bash
 docker run -p 3000:8080 bentopdf/bentopdf:latest
+```
+
+**Using GitHub Container Registry:**
+```bash
+docker run -p 3000:8080 ghcr.io/alam00000/bentopdf:latest
 ```
 
 Open your browser at: http://localhost:3000
@@ -171,11 +177,17 @@ For detailed security configuration, see [SECURITY.md](SECURITY.md).
 
 ### 📦 Version Management
 
-BentoPDF supports semantic versioning with multiple Docker tags:
+BentoPDF supports semantic versioning with multiple Docker tags available on both Docker Hub and GitHub Container Registry:
 
+**Docker Hub:**
 - **Latest**: `bentopdf/bentopdf:latest`
 - **Specific Version**: `bentopdf/bentopdf:1.0.0`
 - **Version with Prefix**: `bentopdf/bentopdf:v1.0.0`
+
+**GitHub Container Registry:**
+- **Latest**: `ghcr.io/alam00000/bentopdf:latest`
+- **Specific Version**: `ghcr.io/alam00000/bentopdf:1.0.0`
+- **Version with Prefix**: `ghcr.io/alam00000/bentopdf:v1.0.0`
 
 #### Quick Release
 

--- a/SIMPLE_MODE.md
+++ b/SIMPLE_MODE.md
@@ -23,16 +23,24 @@ When enabled, Simple Mode will:
 
 Use the pre-built Simple Mode image directly:
 
+**Using Docker Hub:**
 ```bash
 docker run -p 3000:80 bentopdf/bentopdf-simple:latest
 ```
 
+**Using GitHub Container Registry:**
+```bash
+docker run -p 3000:80 ghcr.io/alam00000/bentopdf-simple:latest
+```
 Or with Docker Compose:
 
 ```yaml
 services:
   bentopdf:
+    # Using Docker Hub
     image: bentopdf/bentopdf-simple:latest
+    # Or using GitHub Container Registry
+    # image: ghcr.io/alam00000/bentopdf-simple:latest
     container_name: bentopdf
     restart: unless-stopped
     ports:
@@ -142,13 +150,23 @@ When Simple Mode is working correctly, you should see:
 
 ### Normal Mode (Full Branding)
 
+**Docker Hub:**
 - `bentopdf/bentopdf:latest`
 - `bentopdf/bentopdf:v1.0.0` (versioned)
 
+**GitHub Container Registry:**
+- `ghcr.io/alam00000/bentopdf:latest`
+- `ghcr.io/alam00000/bentopdf:v1.0.0` (versioned)
+
 ### Simple Mode (Clean Interface)
 
+**Docker Hub:**
 - `bentopdf/bentopdf-simple:latest`
 - `bentopdf/bentopdf-simple:v1.0.0` (versioned)
+
+**GitHub Container Registry:**
+- `ghcr.io/alam00000/bentopdf-simple:latest`
+- `ghcr.io/alam00000/bentopdf-simple:v1.0.0` (versioned)
 
 ## 🚀 Production Deployment Examples
 


### PR DESCRIPTION
### Description

Adds GitHub Container Registry (GHCR) publishing to complement Docker Hub. The workflow publishes images to both registries with the same tags 

Fixes # (issue)
https://github.com/alam00000/bentopdf/issues/103

### Type of change

- [x] This change requires a documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
