### PR TITLE
Add French localization for common phrases

### DIFF
--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -1,0 +1,84 @@
+{
+  "nav": {
+    "home": "Accueil",
+    "about": "À propos",
+    "contact": "Contact",
+    "licensing": "Licence",
+    "allTools": "Tous les outils",
+    "openMainMenu": "Ouvrir le menu principal",
+    "language": "Langue"
+  },
+  "hero": {
+    "title": "La",
+    "pdfToolkit": "boîte à outils PDF",
+    "builtForPrivacy": "respectueuse de la confidentialité",
+    "noSignups": "Sans inscription",
+    "unlimitedUse": "Utilisation illimitée",
+    "worksOffline": "Fonctionne hors ligne",
+    "startUsing": "Commencer maintenant"
+  },
+  "usedBy": {
+    "title": "Utilisé par des entreprises et des professionnels chez"
+  },
+  "features": {
+    "title": "Pourquoi choisir",
+    "bentoPdf": "BentoPDF ?",
+    "noSignup": {
+      "title": "Sans inscription",
+      "description": "Démarrez instantanément, sans compte ni e-mail."
+    },
+    "noUploads": {
+      "title": "Aucun téléversement",
+      "description": "100 % côté client, vos fichiers ne quittent jamais votre appareil."
+    },
+    "foreverFree": {
+      "title": "Gratuit pour toujours",
+      "description": "Tous les outils, sans essai ni mur payant."
+    },
+    "noLimits": {
+      "title": "Sans limites",
+      "description": "Utilisation libre, sans restriction cachée."
+    },
+    "batchProcessing": {
+      "title": "Traitement par lots",
+      "description": "Traitez un nombre illimité de PDF en une seule fois."
+    },
+    "lightningFast": {
+      "title": "Ultra rapide",
+      "description": "Traitement instantané des PDF, sans attente."
+    }
+  },
+  "tools": {
+    "title": "Commencer avec",
+    "toolsLabel": "Outils",
+    "subtitle": "Cliquez sur un outil pour ouvrir le sélecteur de fichiers",
+    "searchPlaceholder": "Rechercher un outil (ex. « fractionner », « organiser »...)",
+    "backToTools": "Retour aux outils"
+  },
+  "upload": {
+    "clickToSelect": "Cliquez pour sélectionner un fichier",
+    "orDragAndDrop": "ou glissez-déposez",
+    "pdfOrImages": "PDF ou images",
+    "filesNeverLeave": "Vos fichiers ne quittent jamais votre appareil.",
+    "addMore": "Ajouter d’autres fichiers",
+    "clearAll": "Tout effacer"
+  },
+  "loader": {
+    "processing": "Traitement en cours..."
+  },
+  "alert": {
+    "title": "Alerte",
+    "ok": "OK"
+  },
+  "preview": {
+    "title": "Aperçu du document",
+    "downloadAsPdf": "Télécharger en PDF",
+    "close": "Fermer"
+  },
+  "settings": {
+    "title": "Paramètres",
+    "shortcuts": "Raccourcis",
+    "preferences": "Préférences",
+    "displayPreferences": "Préférences d’affichage",
+    "searchShortcuts": "Rechercher des raccourcis...",
+    "shortcutsInfo": "Maintenez les touches enfoncées pour définir un rac


### PR DESCRIPTION
### Description

This pull request completes the French localization (FR) for the BentoPDF self-hosted application by translating all remaining UI strings and tool catalog labels/subtitles from English to French.

Scope includes:

- Navigation and landing-page copy
- Feature and compliance sections
- FAQ/testimonials/support/footer strings
- Tool categories and individual tool names/subtitles (including stamps fields and metadata/security tools)

Motivation:

- Provide a fully consistent French UI for French-speaking deployments and avoid mixed-language screens.

Dependencies:

- None.

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### 🧪 How Has This Been Tested?

Haven't tested the UI as i'm not really a developper, just contributing with the materials.

**Checklist:**

- [ ] Verified output manually
- [ ] Tested with relevant sample documents or data
- [ ] Wrote Vite Test Case (if applicable)

**Expected Results:**

French text should be displayed consistently accross the UI (no unstranslated English strings remain for the updated keys).

**Actual Results:**

Please someone could test this? Really new to github PR.

### Checklist:

- [ ] I have signed the [Contributor License Agreement (CLA)](ICLA.md) or my organization has signed the [Corporate CLA](CCLA.md)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
