### PR TITLE
Fix edit-pdf-page.ts and revert fileHandler.ts (EmbedPDF.js snippet fix)

### DIFF
--- a/src/js/handlers/fileHandler.ts
+++ b/src/js/handlers/fileHandler.ts
@@ -23,11 +23,6 @@ import * as pdfjsLib from 'pdfjs-dist';
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = new URL('pdfjs-dist/build/pdf.worker.min.mjs', import.meta.url).toString();
 
-const embedPdfWasmUrl = new URL(
-  'embedpdf-snippet/dist/pdfium.wasm',
-  import.meta.url
-).href;
-
 // Re-export rotation state utilities
 export { getRotationState, updateRotationState, resetRotationState, initializeRotationState } from '../utils/rotation-state.js';
 
@@ -826,40 +821,6 @@ export function setupFileInputHandler(toolId) {
           }
         };
       }
-    } else if (toolId === 'edit') {
-      const file = state.files[0];
-      if (!file) return;
-
-      const pdfWrapper = document.getElementById('embed-pdf-wrapper');
-      const pdfContainer = document.getElementById('embed-pdf-container');
-
-      if (!pdfContainer) return;
-
-      pdfContainer.textContent = ''; // Clear safely
-
-      if (state.currentPdfUrl) {
-        URL.revokeObjectURL(state.currentPdfUrl);
-      }
-      pdfWrapper.classList.remove('hidden');
-      const fileURL = URL.createObjectURL(file);
-      state.currentPdfUrl = fileURL;
-
-      const { default: EmbedPDF } = await import('embedpdf-snippet');
-      EmbedPDF.init({
-        type: 'container',
-        target: pdfContainer,
-        src: fileURL,
-        worker: true,
-        wasmUrl: embedPdfWasmUrl,
-      });
-
-      const backBtn = document.getElementById('back-to-grid');
-      const urlRevoker = () => {
-        URL.revokeObjectURL(fileURL);
-        state.currentPdfUrl = null;
-        backBtn.removeEventListener('click', urlRevoker);
-      };
-      backBtn.addEventListener('click', urlRevoker);
     }
   };
 

--- a/src/js/logic/edit-pdf-page.ts
+++ b/src/js/logic/edit-pdf-page.ts
@@ -3,6 +3,11 @@ import { createIcons, icons } from 'lucide';
 import { showAlert, showLoader, hideLoader } from '../ui.js';
 import { formatBytes } from '../utils/helpers.js';
 
+const embedPdfWasmUrl = new URL(
+  'embedpdf-snippet/dist/pdfium.wasm',
+  import.meta.url
+).href;
+
 let currentPdfUrl: string | null = null;
 
 if (document.readyState === 'loading') {
@@ -130,18 +135,14 @@ async function handleFiles(files: FileList) {
         const fileURL = URL.createObjectURL(file);
         currentPdfUrl = fileURL;
 
-        // Dynamically load EmbedPDF script
-        const script = document.createElement('script');
-        script.type = 'module';
-        script.textContent = `
-        import EmbedPDF from 'https://snippet.embedpdf.com/embedpdf.js';
+        const { default: EmbedPDF } = await import('embedpdf-snippet');
         EmbedPDF.init({
             type: 'container',
-            target: document.getElementById('embed-pdf-container'),
-            src: '${fileURL}',
+            target: pdfContainer,
+            src: fileURL,
+            worker: true,
+            wasmUrl: embedPdfWasmUrl,
         });
-    `;
-        document.head.appendChild(script);
 
         // Update back button to reset state
         const backBtn = document.getElementById('back-to-tools');


### PR DESCRIPTION
### Description

I did not realize that the edit page actually was moved to its own page like the others. So the previous commit actually did nothing for embedding the EmbedPDF.js module. I've reverted the changes to fileHandler.ts and moved them over to the edit-pdf-page.ts.

(Fixes #236)

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### 🧪 How Has This Been Tested?

Built locally via docker build. Now working without external references.

### Checklist:
- [x] I have signed the [Contributor License Agreement (CLA)](ICLA.md) or my organization has signed the [Corporate CLA](CCLA.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
