### PR TITLE
Remove WASM MIME type and disable Brotli static compression.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -8,11 +8,9 @@ http {
     include /etc/nginx/mime.types;
     types {
         application/javascript mjs;
-        application/wasm wasm;
     }
     default_type application/octet-stream;
 
-    brotli_static on;
     gzip_static on;
     
     gzip on;


### PR DESCRIPTION
### Description

Removed the duplicate MIME type declaration for WASM files and disabled Brotli static compression which is not supported by the standard Docker Nginx image.

**Issue fixed:**
- `duplicate extension "wasm"` warning: the MIME type `application/wasm` was defined both in `/etc/nginx/mime.types` and manually in the `types` block
- `unknown directive "brotli_static"` error: the `brotli_static` directive requires the `ngx_brotli` module which is not included in the official Nginx image

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### 🧪 How Has This Been Tested?

**Checklist:**
- [x] Verified output manually

**Expected Results:**
- Nginx starts without duplicate extension warnings and without unknown directive errors

**Actual Results:**
- Nginx starts correctly without `[emerg]` errors or `[warn]` warnings

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
