### PR TITLE
Fix subdirectory hosting for static pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -86,6 +86,8 @@ function rewriteHtmlPathsPlugin(): Plugin {
   const baseUrl = process.env.BASE_URL || '/';
   const normalizedBase = baseUrl.replace(/\/?$/, '/');
 
+  const escapedBase = normalizedBase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
   return {
     name: 'rewrite-html-paths',
     enforce: 'post',
@@ -96,10 +98,14 @@ function rewriteHtmlPathsPlugin(): Plugin {
         if (fileName.endsWith('.html')) {
           const asset = bundle[fileName];
           if (asset.type === 'asset' && typeof asset.source === 'string') {
+            const hrefRegex = new RegExp(`href="\\/(?!${escapedBase.slice(1)}|test\\/|http|\\/\\/)`, 'g');
+            const srcRegex = new RegExp(`src="\\/(?!${escapedBase.slice(1)}|test\\/|http|\\/\\/)`, 'g');
+            const contentRegex = new RegExp(`content="\\/(?!${escapedBase.slice(1)}|test\\/|http|\\/\\/)`, 'g');
+
             asset.source = asset.source
-              .replace(/href="\/(?!test\/|http|\/\/)/g, `href="${normalizedBase}`)
-              .replace(/src="\/(?!test\/|http|\/\/)/g, `src="${normalizedBase}`)
-              .replace(/content="\/(?!test\/|http|\/\/)/g, `content="${normalizedBase}`);
+              .replace(hrefRegex, `href="${normalizedBase}`)
+              .replace(srcRegex, `src="${normalizedBase}`)
+              .replace(contentRegex, `content="${normalizedBase}`);
           }
         }
       }


### PR DESCRIPTION
### Description

Fix double BASE_URL prefixing issue when deploying to subdirectories.

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### 🧪 How Has This Been Tested?

1. Built the project with `BASE_URL=/bentopdf`
2. Deployed to GitHub Pages using GitHub Actions
3. Verified the live website works correctly at the subdirectory URL

**Checklist:**

- [x] Verified output manually
- [ ] Tested with relevant sample documents or data
- [ ] Wrote Vite Test Case (if applicable)

**Expected Results:**

- When building with `BASE_URL=/xyz/`, HTML files should contain paths like `/xyz/assets/script.js`
- No doubled paths like `/xyz/xyz/assets/script.js`

**Actual Results:**

- Built the project with `BASE_URL=/xyz/ npm run build`
- Confirmed all href/src attributes have correct single-prefixed paths

### Checklist:

- [x] I have signed the [Contributor License Agreement (CLA)](ICLA.md) or my organization has signed the [Corporate CLA](CCLA.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
