### PR TITLE
(Fix) Rotate watermark text around centre of page

### DIFF
--- a/src/js/logic/add-watermark-page.ts
+++ b/src/js/logic/add-watermark-page.ts
@@ -178,8 +178,8 @@ async function addWatermark() {
                 const textWidth = watermarkAsset.widthOfTextAtSize(text, fontSize);
 
                 page.drawText(text, {
-                    x: (width - textWidth) / 2,
-                    y: height / 2,
+                    x: (width / 2) - ((textWidth / 2) * Math.cos(angle * Math.PI / 180)),
+                    y: (height / 2) - ((textWidth / 2) * Math.sin(angle * Math.PI / 180)),
                     font: watermarkAsset,
                     size: fontSize,
                     color: rgb(textColor.r, textColor.g, textColor.b),


### PR DESCRIPTION
### Description

Watermark text will now appear to rotate around the page centre, rather than from the top left corner of the text element. I believe this is more in line with user expectations.

The text position coordinates are now determined in a [polar coordinate reference frame](https://en.wikipedia.org/wiki/Polar_coordinate_system#Converting_between_polar_and_Cartesian_coordinates) and translated to x,y coordinates.

Example of the previous behaviour:

<img src="https://github.com/user-attachments/assets/ade1c962-a4ce-4d26-9e77-1ca558e0a1d2" width="300">

Fixes #196 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### 🧪 How Has This Been Tested?

Manually tested the output for a range of watermark angles (-45,0,35,45) and font sizes (44, 48, 56, 72). 

**Checklist:**

- [x] Verified output manually
- [x] Tested with relevant sample documents or data

**Expected Results:**

 - Text should be rotated about the centre of the document.

**Actual Results:**
- Text indeed appears to be rotated around a central point from all tested angles (-45,0,30,45) and font sizes (44, 48, 56, 72)
- There might be a slight vertical offset in the position of the text which means it doesn't go perfectly from corner to corner. 

New behaviour (font size 72, angle -45):

<img src="https://github.com/user-attachments/assets/a1347e5a-b87a-4bc5-8c3c-fb7f778f1eee" width="300">

### Checklist:

- [x] I have signed the [Contributor License Agreement (CLA)](ICLA.md) or my organization has signed the [Corporate CLA](CCLA.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes*
- [x] Any dependent changes have been merged and published in downstream modules

*none of the failed tests are a result of these changes.

