### PR TITLE
Correction on pdfToExcel.name (Portuguese)

### DIFF
--- a/public/locales/pt/tools.json
+++ b/public/locales/pt/tools.json
@@ -507,7 +507,7 @@
     "subtitle": "Extrai tabelas do PDF e converte em CSV."
   },
   "pdfToExcel": {
-    "name": "PDF to Excel",
+    "name": "PDF para Excel",
     "subtitle": "Extrai tabelas do PDF e converte em Excel (XLSX)."
   },
   "pdfToText": {


### PR DESCRIPTION
### Description

Just 1 line wasn't translated
