### PR TITLE
add Korean (ko) translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ BentoPDF is available in multiple languages:
 | Portuguese          | [![Portuguese](https://img.shields.io/badge/Complete-green?style=flat-square)](public/locales/pt/common.json)             |
 | Turkish             | [![Turkish](https://img.shields.io/badge/Complete-green?style=flat-square)](public/locales/tr/common.json)                |
 | Vietnamese          | [![Vietnamese](https://img.shields.io/badge/Complete-green?style=flat-square)](public/locales/vi/common.json)             |
+| Korean              | [![Korean](https://img.shields.io/badge/Complete-green?style=flat-square)](public/locales/ko/common.json)                 |
 
 Want to help translate BentoPDF into your language? Check out our [Translation Guide](TRANSLATION.md)!
 

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -31,6 +31,7 @@ BentoPDF uses **i18next** for internationalization (i18n). Currently supported l
 - **Indonesian** (`id`)
 - **Chinese** (`zh`)
 - **Traditional Chinese (Taiwan)** (`zh-TW`)
+- **Korean** (`ko`)
 
 The app automatically detects the language from the URL path:
 
@@ -599,6 +600,7 @@ Current translation coverage:
 | Indonesian          | `id`    | ✅ Complete    | Community  |
 | Chinese             | `zh`    | ✅ Complete    | Community  |
 | Traditional Chinese | `zh-TW` | ✅ Complete    | Community  |
+| Korean              | `ko`    | ✅ Complete    | Community  |
 | Your Language       | `??`    | 🚧 In Progress | You?       |
 
 ---

--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -1,0 +1,365 @@
+{
+  "nav": {
+    "home": "홈",
+    "about": "소개",
+    "contact": "문의",
+    "licensing": "라이선스",
+    "allTools": "모든 도구",
+    "openMainMenu": "메인 메뉴 열기",
+    "language": "언어"
+  },
+  "donation": {
+    "message": "BentoPDF가 마음에 드셨나요? 무료 오픈소스로 유지될 수 있도록 도와주세요!",
+    "button": "후원하기"
+  },
+  "hero": {
+    "title": "개인정보 보호를 위해 만든",
+    "pdfToolkit": "PDF 도구 모음",
+    "builtForPrivacy": " ",
+    "noSignups": "회원가입 불필요",
+    "unlimitedUse": "무제한 사용",
+    "worksOffline": "오프라인 지원",
+    "startUsing": "지금 시작하기"
+  },
+  "usedBy": {
+    "title": "다양한 기업과 사용자들이 함께하고 있습니다"
+  },
+  "features": {
+    "title": "왜",
+    "bentoPdf": "BentoPDF일까요?",
+    "noSignup": {
+      "title": "회원가입 불필요",
+      "description": "계정이나 이메일 없이 바로 시작하세요."
+    },
+    "noUploads": {
+      "title": "파일 업로드 없음",
+      "description": "100% 브라우저에서 처리되어 파일이 기기 밖으로 나가지 않습니다."
+    },
+    "foreverFree": {
+      "title": "영원히 무료",
+      "description": "모든 도구를 무료로, 체험판도 유료 기능도 없습니다."
+    },
+    "noLimits": {
+      "title": "사용 제한 없음",
+      "description": "원하는 만큼 자유롭게 사용하세요."
+    },
+    "batchProcessing": {
+      "title": "일괄 처리",
+      "description": "여러 PDF를 한 번에 처리할 수 있습니다."
+    },
+    "lightningFast": {
+      "title": "빠른 처리 속도",
+      "description": "기다릴 필요 없이 PDF를 즉시 처리합니다."
+    }
+  },
+  "tools": {
+    "title": "시작하기",
+    "toolsLabel": "도구",
+    "subtitle": "도구를 클릭하면 파일 업로더가 열립니다",
+    "searchPlaceholder": "도구 검색 (예: '분할', '병합'...)",
+    "backToTools": "도구 목록으로 돌아가기",
+    "firstLoadNotice": "처음에는 변환 엔진을 다운로드하느라 시간이 조금 걸릴 수 있습니다. 이후에는 바로 실행됩니다."
+  },
+  "upload": {
+    "clickToSelect": "클릭하여 파일 선택",
+    "orDragAndDrop": "또는 파일을 끌어다 놓으세요",
+    "pdfOrImages": "PDF 또는 이미지",
+    "filesNeverLeave": "파일이 기기 밖으로 나가지 않습니다.",
+    "addMore": "파일 추가",
+    "clearAll": "모두 지우기",
+    "clearFiles": "파일 지우기",
+    "hints": {
+      "singlePdf": "PDF 파일 1개",
+      "pdfFile": "PDF 파일",
+      "multiplePdfs2": "PDF 파일 2개 이상",
+      "bmpImages": "BMP 이미지",
+      "oneOrMorePdfs": "PDF 파일 1개 이상",
+      "pdfDocuments": "PDF 문서",
+      "oneOrMoreCsv": "CSV 파일 1개 이상",
+      "multiplePdfsSupported": "여러 PDF 파일 지원",
+      "singleOrMultiplePdfs": "PDF 파일 1개 또는 여러 개",
+      "singlePdfFile": "PDF 파일 1개",
+      "pdfWithForms": "양식이 포함된 PDF 파일",
+      "heicImages": "HEIC/HEIF 이미지",
+      "jpgImages": "JPG, JPEG, JP2, JPX 이미지",
+      "pdfsOrImages": "PDF 또는 이미지",
+      "oneOrMoreOdt": "ODT 파일 1개 이상",
+      "singlePdfOnly": "PDF 파일 1개만",
+      "pdfFiles": "PDF 파일",
+      "multiplePdfs": "여러 PDF 파일",
+      "pngImages": "PNG 이미지",
+      "pdfFilesOneOrMore": "PDF 파일 (1개 이상)",
+      "oneOrMoreRtf": "RTF 파일 1개 이상",
+      "svgGraphics": "SVG 그래픽",
+      "tiffImages": "TIFF 이미지",
+      "webpImages": "WebP 이미지"
+    }
+  },
+  "howItWorks": {
+    "title": "이용 방법",
+    "step1": "파일을 클릭하거나 끌어다 놓아 시작하세요",
+    "step2": "처리 버튼을 눌러 변환을 시작하세요",
+    "step3": "완성된 파일을 바로 저장하세요"
+  },
+  "relatedTools": {
+    "title": "관련 PDF 도구"
+  },
+  "loader": {
+    "processing": "처리 중..."
+  },
+  "alert": {
+    "title": "알림",
+    "ok": "확인"
+  },
+  "preview": {
+    "title": "문서 미리보기",
+    "downloadAsPdf": "PDF로 다운로드",
+    "close": "닫기"
+  },
+  "settings": {
+    "title": "설정",
+    "shortcuts": "단축키",
+    "preferences": "환경설정",
+    "displayPreferences": "화면 설정",
+    "searchShortcuts": "단축키 검색...",
+    "shortcutsInfo": "키를 길게 눌러 단축키를 설정할 수 있습니다. 변경 사항은 자동 저장됩니다.",
+    "shortcutsWarning": "⚠️ 브라우저 기본 단축키(Cmd/Ctrl+W, Cmd/Ctrl+T, Cmd/Ctrl+N 등)는 제대로 작동하지 않을 수 있으니 피해 주세요.",
+    "import": "가져오기",
+    "export": "내보내기",
+    "resetToDefaults": "기본값으로 초기화",
+    "fullWidthMode": "전체 너비 모드",
+    "fullWidthDescription": "가운데 정렬 대신 화면 전체 너비를 사용합니다",
+    "settingsAutoSaved": "설정은 자동으로 저장됩니다",
+    "clickToSet": "클릭하여 설정",
+    "pressKeys": "키를 누르세요...",
+    "warnings": {
+      "alreadyInUse": "이미 사용 중인 단축키",
+      "assignedTo": "다음 항목에 이미 지정되어 있습니다:",
+      "chooseDifferent": "다른 단축키를 선택해 주세요.",
+      "reserved": "예약된 단축키 경고",
+      "commonlyUsed": "일반적으로 다음 용도로 사용됩니다:",
+      "unreliable": "이 단축키는 브라우저나 시스템 동작과 충돌할 수 있습니다.",
+      "useAnyway": "그래도 사용하시겠습니까?",
+      "resetTitle": "단축키 초기화",
+      "resetMessage": "모든 단축키를 기본값으로 초기화할까요?<br><br>이 작업은 되돌릴 수 없습니다.",
+      "importSuccessTitle": "가져오기 완료",
+      "importSuccessMessage": "단축키를 가져왔습니다!",
+      "importFailTitle": "가져오기 실패",
+      "importFailMessage": "단축키를 가져올 수 없습니다. 파일 형식이 올바르지 않습니다."
+    }
+  },
+  "warning": {
+    "title": "경고",
+    "cancel": "취소",
+    "proceed": "계속"
+  },
+  "compliance": {
+    "title": "데이터가 기기 밖으로 나가지 않습니다",
+    "weKeep": "글로벌 보안 표준을 준수하여",
+    "yourInfoSafe": "여러분의 정보를",
+    "byFollowingStandards": "안전하게 보호합니다.",
+    "processingLocal": "모든 처리는 사용자의 기기에서 직접 이루어집니다.",
+    "gdpr": {
+      "title": "GDPR 준수",
+      "description": "유럽연합 내 개인정보 및 프라이버시를 보호합니다."
+    },
+    "ccpa": {
+      "title": "CCPA 준수",
+      "description": "캘리포니아 주민의 개인정보 수집, 사용, 공유에 대한 권리를 보장합니다."
+    },
+    "hipaa": {
+      "title": "HIPAA 준수",
+      "description": "미국 의료 시스템에서 민감한 건강 정보를 안전하게 보호합니다."
+    }
+  },
+  "faq": {
+    "title": "자주 묻는",
+    "questions": "질문",
+    "sectionTitle": "자주 묻는 질문",
+    "isFree": {
+      "question": "BentoPDF는 정말 무료인가요?",
+      "answer": "네, 완전히 무료입니다. BentoPDF의 모든 도구는 파일 수 제한, 회원가입, 워터마크 없이 자유롭게 사용할 수 있습니다. 누구나 비용 걱정 없이 편리한 PDF 도구를 쓸 수 있어야 한다고 생각합니다."
+    },
+    "areFilesSecure": {
+      "question": "파일이 안전한가요? 어디에서 처리되나요?",
+      "answer": "파일은 여러분의 컴퓨터를 절대 떠나지 않기 때문에 최대한 안전합니다. 모든 작업은 웹 브라우저 안에서 직접 처리되며, 서버에 파일을 업로드하지 않으므로 문서의 프라이버시를 완벽하게 지킬 수 있습니다."
+    },
+    "platforms": {
+      "question": "Mac, Windows, 모바일에서도 되나요?",
+      "answer": "네! BentoPDF는 브라우저에서 실행되므로 Windows, macOS, Linux, iOS, Android 등 최신 웹 브라우저가 있는 어떤 기기에서든 사용할 수 있습니다."
+    },
+    "gdprCompliant": {
+      "question": "BentoPDF는 GDPR을 준수하나요?",
+      "answer": "네, 완전히 준수합니다. 모든 파일 처리가 브라우저에서 이루어지고 서버로 파일을 전송하지 않기 때문에, 저희는 여러분의 데이터에 접근할 수 없습니다. 문서에 대한 통제권은 항상 여러분에게 있습니다."
+    },
+    "dataStorage": {
+      "question": "파일을 저장하거나 추적하나요?",
+      "answer": "아니요. 파일을 저장하거나 추적하거나 기록하지 않습니다. BentoPDF에서 하는 모든 작업은 브라우저 메모리에서 처리되며, 페이지를 닫으면 모두 사라집니다. 업로드도, 이용 기록도, 서버도 관여하지 않습니다."
+    },
+    "different": {
+      "question": "BentoPDF가 다른 PDF 도구와 다른 점은 뭔가요?",
+      "answer": "대부분의 PDF 도구는 파일을 서버에 업로드해서 처리합니다. BentoPDF는 그렇게 하지 않습니다. 최신 웹 기술을 활용해 브라우저에서 바로 처리하기 때문에 더 빠르고, 더 안전하며, 걱정 없이 사용할 수 있습니다."
+    },
+    "browserBased": {
+      "question": "브라우저 기반 처리가 왜 안전한가요?",
+      "answer": "BentoPDF는 브라우저 안에서만 실행되기 때문에 파일이 기기 밖으로 나가지 않습니다. 서버 해킹, 데이터 유출, 무단 접근 같은 위험이 원천적으로 차단됩니다. 파일은 언제나 여러분만의 것입니다."
+    },
+    "analytics": {
+      "question": "쿠키나 분석 도구로 사용자를 추적하나요?",
+      "answer": "여러분의 프라이버시를 소중히 여깁니다. BentoPDF는 개인정보를 추적하지 않으며, 익명 방문 수 확인만을 위해 Simple Analytics를 사용합니다. 방문자 수는 알 수 있지만 누가 방문했는지는 절대 알 수 없습니다. Simple Analytics는 GDPR을 완전히 준수합니다."
+    }
+  },
+  "testimonials": {
+    "title": "사용자",
+    "users": "후기",
+    "say": ""
+  },
+  "support": {
+    "title": "도움이 되셨나요?",
+    "description": "BentoPDF는 누구나 무료로, 안전하게, 강력한 PDF 도구를 사용할 수 있도록 만든 프로젝트입니다. 유용하게 쓰고 계시다면 개발을 응원해 주세요. 작은 후원이 큰 힘이 됩니다!",
+    "buyMeCoffee": "커피 한 잔 사주기"
+  },
+  "footer": {
+    "copyright": "© 2026 BentoPDF. All rights reserved.",
+    "version": "버전",
+    "company": "회사",
+    "aboutUs": "소개",
+    "faqLink": "FAQ",
+    "contactUs": "문의하기",
+    "legal": "법적 고지",
+    "termsAndConditions": "이용약관",
+    "privacyPolicy": "개인정보처리방침",
+    "followUs": "팔로우"
+  },
+  "merge": {
+    "title": "PDF 병합",
+    "description": "여러 파일을 합치거나, 원하는 페이지만 골라 새 문서로 만들 수 있습니다.",
+    "fileMode": "파일 모드",
+    "pageMode": "페이지 모드",
+    "howItWorks": "이용 방법:",
+    "fileModeInstructions": [
+      "아이콘을 드래그하여 파일 순서를 변경할 수 있습니다.",
+      "각 파일의 \"페이지\" 란에 원하는 범위를 입력하세요 (예: \"1-3, 5\").",
+      "\"페이지\" 란을 비워두면 해당 파일의 전체 페이지가 포함됩니다."
+    ],
+    "pageModeInstructions": [
+      "업로드한 PDF의 모든 페이지가 아래에 나타납니다.",
+      "페이지 미리보기를 드래그하여 원하는 순서로 배치하세요."
+    ],
+    "mergePdfs": "PDF 병합하기"
+  },
+  "common": {
+    "page": "페이지",
+    "pages": "페이지",
+    "of": "/",
+    "download": "다운로드",
+    "cancel": "취소",
+    "save": "저장",
+    "delete": "삭제",
+    "edit": "편집",
+    "add": "추가",
+    "remove": "제거",
+    "loading": "불러오는 중...",
+    "error": "오류",
+    "success": "완료",
+    "file": "파일",
+    "files": "파일",
+    "close": "닫기"
+  },
+  "about": {
+    "hero": {
+      "title": "PDF 도구는 마땅히",
+      "subtitle": "빠르고, 안전하고, 무료여야 합니다.",
+      "noCompromises": "타협 없이."
+    },
+    "mission": {
+      "title": "우리의 목표",
+      "description": "프라이버시를 지키면서도 비용 부담 없는, 가장 완벽한 PDF 도구를 만드는 것입니다. 꼭 필요한 문서 도구는 누구나, 어디서든 자유롭게 쓸 수 있어야 합니다."
+    },
+    "philosophy": {
+      "label": "핵심 철학",
+      "title": "개인정보 보호가 최우선. 언제나.",
+      "description": "데이터가 곧 상품인 시대에, 우리는 다른 길을 걷습니다. BentoPDF의 모든 처리는 브라우저에서 직접 이루어집니다. 파일이 서버로 전송되지 않고, 문서를 들여다보지 않으며, 사용 내역을 추적하지 않습니다. 여러분의 문서는 철저하게 비공개로 유지됩니다. 이것은 하나의 기능이 아니라 우리의 근본입니다."
+    },
+    "whyBentopdf": {
+      "title": "왜",
+      "speed": {
+        "title": "속도에 최적화",
+        "description": "서버로 파일을 올리고 내려받을 필요가 없습니다. WebAssembly 등 최신 웹 기술로 브라우저에서 바로 처리하여 압도적인 속도를 제공합니다."
+      },
+      "free": {
+        "title": "완전 무료",
+        "description": "체험판, 구독, 숨겨진 요금, 잠긴 \"프리미엄\" 기능이 없습니다. 강력한 PDF 도구는 돈을 내야 쓸 수 있는 것이 아니라 누구에게나 열려 있어야 합니다."
+      },
+      "noAccount": {
+        "title": "계정 없이 바로 사용",
+        "description": "이메일도, 비밀번호도, 개인정보도 필요 없습니다. 원하는 도구를 바로 사용하세요."
+      },
+      "openSource": {
+        "title": "오픈소스 정신",
+        "description": "투명성을 바탕으로 만들어졌습니다. PDF-lib, PDF.js 등 뛰어난 오픈소스 라이브러리를 활용하며, 좋은 도구를 누구나 쓸 수 있게 만드는 커뮤니티의 힘을 믿습니다."
+      }
+    },
+    "cta": {
+      "title": "시작할 준비가 되셨나요?",
+      "description": "수많은 사용자가 일상적인 문서 작업에 BentoPDF를 활용하고 있습니다. 프라이버시와 빠른 성능이 가져다주는 차이를 직접 느껴보세요.",
+      "button": "모든 도구 둘러보기"
+    }
+  },
+  "contact": {
+    "title": "문의하기",
+    "subtitle": "질문, 피드백, 기능 요청 등 무엇이든 편하게 연락해 주세요.",
+    "email": "아래 이메일로 직접 연락하실 수 있습니다:"
+  },
+  "licensing": {
+    "title": "라이선스",
+    "subtitle": "필요에 맞는 라이선스를 선택하세요."
+  },
+  "multiTool": {
+    "uploadPdfs": "PDF 업로드",
+    "upload": "업로드",
+    "addBlankPage": "빈 페이지 추가",
+    "edit": "편집:",
+    "undo": "실행 취소",
+    "redo": "다시 실행",
+    "reset": "초기화",
+    "selection": "선택:",
+    "selectAll": "모두 선택",
+    "deselectAll": "선택 해제",
+    "rotate": "회전:",
+    "rotateLeft": "왼쪽",
+    "rotateRight": "오른쪽",
+    "transform": "변환:",
+    "duplicate": "복제",
+    "split": "분할",
+    "clear": "지우기:",
+    "delete": "삭제",
+    "download": "다운로드:",
+    "downloadSelected": "선택 항목 다운로드",
+    "exportPdf": "PDF 내보내기",
+    "uploadPdfFiles": "PDF 파일 선택",
+    "dragAndDrop": "PDF 파일을 여기에 끌어다 놓거나 클릭하여 선택하세요",
+    "selectFiles": "파일 선택",
+    "renderingPages": "페이지 렌더링 중...",
+    "actions": {
+      "duplicatePage": "이 페이지 복제",
+      "deletePage": "이 페이지 삭제",
+      "insertPdf": "이 페이지 뒤에 PDF 삽입",
+      "toggleSplit": "이 페이지 뒤에서 분할"
+    },
+    "pleaseWait": "잠시만요",
+    "pagesRendering": "페이지를 렌더링하는 중입니다. 잠시만 기다려 주세요...",
+    "noPagesSelected": "선택된 페이지 없음",
+    "selectOnePage": "다운로드할 페이지를 하나 이상 선택해 주세요.",
+    "noPages": "페이지 없음",
+    "noPagesToExport": "내보낼 페이지가 없습니다.",
+    "renderingTitle": "페이지 미리보기 생성 중",
+    "errorRendering": "페이지 미리보기를 만들지 못했습니다",
+    "error": "오류",
+    "failedToLoad": "불러오기 실패"
+  },
+  "simpleMode": {
+    "title": "PDF 도구",
+    "subtitle": "사용할 도구를 선택하세요"
+  }
+}

--- a/public/locales/ko/tools.json
+++ b/public/locales/ko/tools.json
@@ -1,0 +1,631 @@
+{
+  "categories": {
+    "popularTools": "인기 도구",
+    "editAnnotate": "편집 및 주석",
+    "convertToPdf": "PDF로 변환",
+    "convertFromPdf": "PDF에서 변환",
+    "organizeManage": "정리 및 관리",
+    "optimizeRepair": "최적화 및 복구",
+    "securePdf": "PDF 보안"
+  },
+  "pdfMultiTool": {
+    "name": "PDF 멀티 도구",
+    "subtitle": "병합, 분할, 정리, 삭제, 회전, 빈 페이지 추가, 추출, 복제를 하나의 화면에서."
+  },
+  "mergePdf": {
+    "name": "PDF 병합",
+    "subtitle": "여러 PDF를 하나로 합칩니다. 북마크도 유지됩니다."
+  },
+  "splitPdf": {
+    "name": "PDF 분할",
+    "subtitle": "원하는 페이지 범위를 새 PDF로 추출합니다."
+  },
+  "compressPdf": {
+    "name": "PDF 압축",
+    "subtitle": "PDF 파일 크기를 줄입니다.",
+    "algorithmLabel": "압축 알고리즘",
+    "condense": "Condense (권장)",
+    "photon": "Photon (사진이 많은 PDF용)",
+    "condenseInfo": "Condense는 불필요한 데이터 제거, 이미지 최적화, 폰트 서브셋 등 고급 압축을 적용합니다. 대부분의 PDF에 적합합니다.",
+    "photonInfo": "Photon은 페이지를 이미지로 변환합니다. 사진이 많거나 스캔된 PDF에 적합합니다.",
+    "photonWarning": "주의: 텍스트 선택이 불가능해지고 링크가 작동하지 않게 됩니다.",
+    "levelLabel": "압축 수준",
+    "light": "낮음 (품질 유지)",
+    "balanced": "보통 (권장)",
+    "aggressive": "높음 (파일 크기 우선)",
+    "extreme": "최대 (최고 압축률)",
+    "grayscale": "흑백으로 변환",
+    "grayscaleHint": "색상 정보를 제거하여 파일 크기를 줄입니다",
+    "customSettings": "사용자 설정",
+    "customSettingsHint": "압축 세부 설정을 조정합니다:",
+    "outputQuality": "출력 품질",
+    "resizeImagesTo": "이미지 크기 조정",
+    "onlyProcessAbove": "이 크기 이상만 처리",
+    "removeMetadata": "메타데이터 제거",
+    "subsetFonts": "폰트 서브셋 (미사용 글자 제거)",
+    "removeThumbnails": "내장 미리보기 이미지 제거",
+    "compressButton": "PDF 압축하기"
+  },
+  "pdfEditor": {
+    "name": "PDF 편집기",
+    "subtitle": "주석, 하이라이트, 마스킹, 댓글, 도형/이미지 추가, 검색 및 보기."
+  },
+  "jpgToPdf": {
+    "name": "JPG를 PDF로",
+    "subtitle": "JPG, JPEG, JPEG2000(JP2/JPX) 이미지로 PDF를 만듭니다."
+  },
+  "signPdf": {
+    "name": "PDF 서명",
+    "subtitle": "서명을 그리거나, 입력하거나, 이미지로 추가하세요."
+  },
+  "cropPdf": {
+    "name": "PDF 자르기",
+    "subtitle": "PDF 모든 페이지의 여백을 잘라냅니다."
+  },
+  "extractPages": {
+    "name": "페이지 추출",
+    "subtitle": "원하는 페이지를 골라 새 파일로 저장합니다."
+  },
+  "duplicateOrganize": {
+    "name": "복제 및 정리",
+    "subtitle": "페이지를 복제하고, 순서를 바꾸고, 삭제합니다."
+  },
+  "deletePages": {
+    "name": "페이지 삭제",
+    "subtitle": "문서에서 특정 페이지를 제거합니다."
+  },
+  "editBookmarks": {
+    "name": "북마크 편집",
+    "subtitle": "PDF 북마크를 추가, 편집, 가져오기, 삭제, 추출합니다."
+  },
+  "tableOfContents": {
+    "name": "목차 생성",
+    "subtitle": "PDF 북마크를 기반으로 목차 페이지를 만듭니다."
+  },
+  "pageNumbers": {
+    "name": "페이지 번호",
+    "subtitle": "문서에 페이지 번호를 삽입합니다."
+  },
+  "batesNumbering": {
+    "name": "베이츠 번호 매기기",
+    "subtitle": "하나 이상의 PDF에 순차적 베이츠 번호를 추가합니다."
+  },
+  "addWatermark": {
+    "name": "워터마크 추가",
+    "subtitle": "PDF 페이지에 텍스트 또는 이미지 워터마크를 넣습니다.",
+    "applyToAllPages": "모든 페이지에 적용"
+  },
+  "headerFooter": {
+    "name": "머리글 및 바닥글",
+    "subtitle": "페이지 상단과 하단에 텍스트를 추가합니다."
+  },
+  "invertColors": {
+    "name": "색상 반전",
+    "subtitle": "PDF를 다크 모드 버전으로 만듭니다."
+  },
+  "scannerEffect": {
+    "name": "스캔 효과",
+    "subtitle": "PDF를 스캔한 문서처럼 보이게 만듭니다.",
+    "scanSettings": "스캔 설정",
+    "colorspace": "색 공간",
+    "gray": "흑백",
+    "border": "테두리",
+    "rotate": "회전",
+    "rotateVariance": "회전 변동",
+    "brightness": "밝기",
+    "contrast": "대비",
+    "blur": "흐림",
+    "noise": "노이즈",
+    "yellowish": "누런 효과",
+    "resolution": "해상도",
+    "processButton": "스캔 효과 적용"
+  },
+  "adjustColors": {
+    "name": "색상 조정",
+    "subtitle": "PDF의 밝기, 대비, 채도 등을 세밀하게 조정합니다.",
+    "colorSettings": "색상 설정",
+    "brightness": "밝기",
+    "contrast": "대비",
+    "saturation": "채도",
+    "hueShift": "색조",
+    "temperature": "색온도",
+    "tint": "틴트",
+    "gamma": "감마",
+    "sepia": "세피아",
+    "processButton": "색상 조정 적용"
+  },
+  "backgroundColor": {
+    "name": "배경색 변경",
+    "subtitle": "PDF의 배경색을 변경합니다."
+  },
+  "changeTextColor": {
+    "name": "텍스트 색상 변경",
+    "subtitle": "PDF의 텍스트 색상을 변경합니다."
+  },
+  "addStamps": {
+    "name": "도장 추가",
+    "subtitle": "주석 도구 모음을 사용하여 PDF에 이미지 도장을 추가합니다.",
+    "usernameLabel": "도장 사용자 이름",
+    "usernamePlaceholder": "이름을 입력하세요 (도장용)",
+    "usernameHint": "이 이름이 도장에 표시됩니다."
+  },
+  "removeAnnotations": {
+    "name": "주석 제거",
+    "subtitle": "댓글, 하이라이트, 링크를 제거합니다."
+  },
+  "pdfFormFiller": {
+    "name": "PDF 양식 작성",
+    "subtitle": "브라우저에서 직접 양식을 작성합니다. XFA 양식도 지원됩니다."
+  },
+  "createPdfForm": {
+    "name": "PDF 양식 만들기",
+    "subtitle": "드래그 앤 드롭으로 작성 가능한 PDF 양식을 만듭니다."
+  },
+  "removeBlankPages": {
+    "name": "빈 페이지 제거",
+    "subtitle": "빈 페이지를 자동으로 감지하고 삭제합니다.",
+    "sensitivityHint": "높을수록 완전히 빈 페이지만 감지합니다. 낮추면 약간의 내용이 있는 페이지도 포함됩니다."
+  },
+  "imageToPdf": {
+    "name": "이미지를 PDF로",
+    "subtitle": "JPG, PNG, BMP, GIF, TIFF, PNM, PGM, PBM, PPM, PAM, JXR, JPX, JP2, PSD, SVG, HEIC, WebP를 PDF로 변환합니다."
+  },
+  "pngToPdf": {
+    "name": "PNG를 PDF로",
+    "subtitle": "PNG 이미지로 PDF를 만듭니다."
+  },
+  "webpToPdf": {
+    "name": "WebP를 PDF로",
+    "subtitle": "WebP 이미지로 PDF를 만듭니다."
+  },
+  "svgToPdf": {
+    "name": "SVG를 PDF로",
+    "subtitle": "SVG 이미지로 PDF를 만듭니다."
+  },
+  "bmpToPdf": {
+    "name": "BMP를 PDF로",
+    "subtitle": "BMP 이미지로 PDF를 만듭니다."
+  },
+  "heicToPdf": {
+    "name": "HEIC를 PDF로",
+    "subtitle": "HEIC 이미지로 PDF를 만듭니다."
+  },
+  "tiffToPdf": {
+    "name": "TIFF를 PDF로",
+    "subtitle": "TIFF 이미지로 PDF를 만듭니다."
+  },
+  "textToPdf": {
+    "name": "텍스트를 PDF로",
+    "subtitle": "일반 텍스트 파일을 PDF로 변환합니다."
+  },
+  "jsonToPdf": {
+    "name": "JSON을 PDF로",
+    "subtitle": "JSON 파일을 PDF 형식으로 변환합니다."
+  },
+  "pdfToJpg": {
+    "name": "PDF를 JPG로",
+    "subtitle": "PDF의 각 페이지를 JPG 이미지로 변환합니다."
+  },
+  "pdfToPng": {
+    "name": "PDF를 PNG로",
+    "subtitle": "PDF의 각 페이지를 PNG 이미지로 변환합니다."
+  },
+  "pdfToWebp": {
+    "name": "PDF를 WebP로",
+    "subtitle": "PDF의 각 페이지를 WebP 이미지로 변환합니다."
+  },
+  "pdfToBmp": {
+    "name": "PDF를 BMP로",
+    "subtitle": "PDF의 각 페이지를 BMP 이미지로 변환합니다."
+  },
+  "pdfToTiff": {
+    "name": "PDF를 TIFF로",
+    "subtitle": "PDF의 각 페이지를 TIFF 이미지로 변환합니다."
+  },
+  "pdfToGreyscale": {
+    "name": "PDF 흑백 변환",
+    "subtitle": "모든 색상을 흑백으로 변환합니다."
+  },
+  "pdfToJson": {
+    "name": "PDF를 JSON으로",
+    "subtitle": "PDF 파일을 JSON 형식으로 변환합니다."
+  },
+  "ocrPdf": {
+    "name": "OCR PDF",
+    "subtitle": "PDF의 텍스트를 검색하고 복사할 수 있게 만듭니다."
+  },
+  "alternateMix": {
+    "name": "페이지 교차 병합",
+    "subtitle": "각 PDF의 페이지를 번갈아 가며 병합합니다. 북마크도 유지됩니다."
+  },
+  "addAttachments": {
+    "name": "첨부파일 추가",
+    "subtitle": "PDF에 파일을 첨부합니다."
+  },
+  "extractAttachments": {
+    "name": "첨부파일 추출",
+    "subtitle": "PDF에 첨부된 모든 파일을 ZIP으로 추출합니다."
+  },
+  "editAttachments": {
+    "name": "첨부파일 편집",
+    "subtitle": "PDF의 첨부파일을 확인하거나 제거합니다."
+  },
+  "dividePages": {
+    "name": "페이지 분할",
+    "subtitle": "페이지를 가로 또는 세로로 나눕니다."
+  },
+  "addBlankPage": {
+    "name": "빈 페이지 추가",
+    "subtitle": "PDF 원하는 위치에 빈 페이지를 삽입합니다."
+  },
+  "reversePages": {
+    "name": "페이지 역순 정렬",
+    "subtitle": "문서의 모든 페이지 순서를 뒤집습니다."
+  },
+  "rotatePdf": {
+    "name": "PDF 회전",
+    "subtitle": "페이지를 90도 단위로 회전합니다."
+  },
+  "rotateCustom": {
+    "name": "사용자 지정 각도 회전",
+    "subtitle": "원하는 각도로 페이지를 회전합니다."
+  },
+  "nUpPdf": {
+    "name": "N-Up PDF",
+    "subtitle": "한 장에 여러 페이지를 배치합니다."
+  },
+  "combineToSinglePage": {
+    "name": "한 페이지로 합치기",
+    "subtitle": "모든 페이지를 하나의 긴 페이지로 이어 붙입니다."
+  },
+  "viewMetadata": {
+    "name": "메타데이터 보기",
+    "subtitle": "PDF에 숨겨진 속성 정보를 확인합니다."
+  },
+  "editMetadata": {
+    "name": "메타데이터 편집",
+    "subtitle": "저자, 제목 등의 속성을 변경합니다."
+  },
+  "pdfsToZip": {
+    "name": "PDF를 ZIP으로",
+    "subtitle": "여러 PDF 파일을 ZIP 파일로 묶습니다."
+  },
+  "comparePdfs": {
+    "name": "PDF 비교",
+    "subtitle": "두 PDF를 나란히 비교합니다."
+  },
+  "posterizePdf": {
+    "name": "PDF 포스터화",
+    "subtitle": "큰 페이지를 여러 작은 페이지로 나눕니다."
+  },
+  "fixPageSize": {
+    "name": "페이지 크기 통일",
+    "subtitle": "모든 페이지를 동일한 크기로 맞춥니다."
+  },
+  "linearizePdf": {
+    "name": "PDF 선형화",
+    "subtitle": "웹에서 빠르게 볼 수 있도록 PDF를 최적화합니다."
+  },
+  "pageDimensions": {
+    "name": "페이지 크기 정보",
+    "subtitle": "페이지 크기, 방향, 단위를 분석합니다."
+  },
+  "removeRestrictions": {
+    "name": "제한 해제",
+    "subtitle": "디지털 서명된 PDF의 비밀번호 보호 및 보안 제한을 해제합니다."
+  },
+  "repairPdf": {
+    "name": "PDF 복구",
+    "subtitle": "손상된 PDF 파일에서 데이터를 복구합니다."
+  },
+  "encryptPdf": {
+    "name": "PDF 암호화",
+    "subtitle": "비밀번호를 설정하여 PDF를 보호합니다."
+  },
+  "sanitizePdf": {
+    "name": "PDF 정리",
+    "subtitle": "메타데이터, 주석, 스크립트 등을 제거합니다."
+  },
+  "decryptPdf": {
+    "name": "PDF 복호화",
+    "subtitle": "비밀번호를 제거하여 PDF 잠금을 해제합니다."
+  },
+  "flattenPdf": {
+    "name": "PDF 평탄화",
+    "subtitle": "양식 필드와 주석을 편집 불가능하게 만듭니다."
+  },
+  "removeMetadata": {
+    "name": "메타데이터 제거",
+    "subtitle": "PDF에서 숨겨진 데이터를 삭제합니다."
+  },
+  "changePermissions": {
+    "name": "권한 변경",
+    "subtitle": "PDF의 사용자 권한을 설정하거나 변경합니다."
+  },
+  "odtToPdf": {
+    "name": "ODT를 PDF로",
+    "subtitle": "ODT(OpenDocument 텍스트) 파일을 PDF로 변환합니다. 여러 파일 지원.",
+    "acceptedFormats": "ODT 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "csvToPdf": {
+    "name": "CSV를 PDF로",
+    "subtitle": "CSV 스프레드시트 파일을 PDF로 변환합니다. 여러 파일 지원.",
+    "acceptedFormats": "CSV 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "rtfToPdf": {
+    "name": "RTF를 PDF로",
+    "subtitle": "RTF(서식 있는 텍스트) 문서를 PDF로 변환합니다. 여러 파일 지원.",
+    "acceptedFormats": "RTF 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "wordToPdf": {
+    "name": "Word를 PDF로",
+    "subtitle": "Word 문서(DOCX, DOC, ODT, RTF)를 PDF로 변환합니다. 여러 파일 지원.",
+    "acceptedFormats": "DOCX, DOC, ODT, RTF 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "excelToPdf": {
+    "name": "Excel을 PDF로",
+    "subtitle": "Excel 스프레드시트(XLSX, XLS, ODS, CSV)를 PDF로 변환합니다. 여러 파일 지원.",
+    "acceptedFormats": "XLSX, XLS, ODS, CSV 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "powerpointToPdf": {
+    "name": "PowerPoint를 PDF로",
+    "subtitle": "PowerPoint 프레젠테이션(PPTX, PPT, ODP)을 PDF로 변환합니다. 여러 파일 지원.",
+    "acceptedFormats": "PPTX, PPT, ODP 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "markdownToPdf": {
+    "name": "Markdown을 PDF로",
+    "subtitle": "Markdown을 작성하거나 붙여넣고 깔끔하게 서식이 적용된 PDF로 내보냅니다.",
+    "paneMarkdown": "Markdown",
+    "panePreview": "미리보기",
+    "btnUpload": "업로드",
+    "btnSyncScroll": "스크롤 동기화",
+    "btnSettings": "설정",
+    "btnExportPdf": "PDF 내보내기",
+    "settingsTitle": "Markdown 설정",
+    "settingsPreset": "프리셋",
+    "presetDefault": "기본 (GFM 스타일)",
+    "presetCommonmark": "CommonMark (엄격)",
+    "presetZero": "최소 (기능 없음)",
+    "settingsOptions": "Markdown 옵션",
+    "optAllowHtml": "HTML 태그 허용",
+    "optBreaks": "줄바꿈을 <br>로 변환",
+    "optLinkify": "URL을 자동으로 링크로 변환",
+    "optTypographer": "타이포그래퍼 (스마트 따옴표 등)"
+  },
+  "pdfBooklet": {
+    "name": "PDF 소책자",
+    "subtitle": "양면 인쇄용으로 페이지를 재배치합니다. 접고 스테이플러로 철하면 소책자가 됩니다.",
+    "howItWorks": "이용 방법:",
+    "step1": "PDF 파일을 업로드합니다.",
+    "step2": "페이지가 소책자 순서로 재배치됩니다.",
+    "step3": "양면 인쇄 후 짧은 면을 기준으로 접어 철합니다.",
+    "paperSize": "용지 크기",
+    "orientation": "방향",
+    "portrait": "세로",
+    "landscape": "가로",
+    "pagesPerSheet": "한 면당 페이지 수",
+    "createBooklet": "소책자 만들기",
+    "processing": "처리 중...",
+    "pageCount": "필요 시 페이지 수가 4의 배수로 맞춰집니다."
+  },
+  "xpsToPdf": {
+    "name": "XPS를 PDF로",
+    "subtitle": "XPS/OXPS 문서를 PDF로 변환합니다. 여러 파일 지원.",
+    "acceptedFormats": "XPS, OXPS 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "mobiToPdf": {
+    "name": "MOBI를 PDF로",
+    "subtitle": "MOBI 전자책을 PDF로 변환합니다. 여러 파일 지원.",
+    "acceptedFormats": "MOBI 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "epubToPdf": {
+    "name": "EPUB를 PDF로",
+    "subtitle": "EPUB 전자책을 PDF로 변환합니다. 여러 파일 지원.",
+    "acceptedFormats": "EPUB 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "fb2ToPdf": {
+    "name": "FB2를 PDF로",
+    "subtitle": "FictionBook(FB2) 전자책을 PDF로 변환합니다. 여러 파일 지원.",
+    "acceptedFormats": "FB2 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "cbzToPdf": {
+    "name": "CBZ를 PDF로",
+    "subtitle": "만화 아카이브(CBZ/CBR)를 PDF로 변환합니다. 여러 파일 지원.",
+    "acceptedFormats": "CBZ, CBR 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "wpdToPdf": {
+    "name": "WPD를 PDF로",
+    "subtitle": "WordPerfect(WPD) 문서를 PDF로 변환합니다. 여러 파일 지원.",
+    "acceptedFormats": "WPD 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "wpsToPdf": {
+    "name": "WPS를 PDF로",
+    "subtitle": "WPS Office 문서를 PDF로 변환합니다. 여러 파일 지원.",
+    "acceptedFormats": "WPS 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "xmlToPdf": {
+    "name": "XML을 PDF로",
+    "subtitle": "XML 문서를 PDF로 변환합니다. 여러 파일 지원.",
+    "acceptedFormats": "XML 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "pagesToPdf": {
+    "name": "Pages를 PDF로",
+    "subtitle": "Apple Pages 문서를 PDF로 변환합니다. 여러 파일 지원.",
+    "acceptedFormats": "Pages 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "odgToPdf": {
+    "name": "ODG를 PDF로",
+    "subtitle": "ODG(OpenDocument 그래픽) 파일을 PDF로 변환합니다. 여러 파일 지원.",
+    "acceptedFormats": "ODG 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "odsToPdf": {
+    "name": "ODS를 PDF로",
+    "subtitle": "ODS(OpenDocument 스프레드시트) 파일을 PDF로 변환합니다. 여러 파일 지원.",
+    "acceptedFormats": "ODS 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "odpToPdf": {
+    "name": "ODP를 PDF로",
+    "subtitle": "ODP(OpenDocument 프레젠테이션) 파일을 PDF로 변환합니다. 여러 파일 지원.",
+    "acceptedFormats": "ODP 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "pubToPdf": {
+    "name": "PUB를 PDF로",
+    "subtitle": "Microsoft Publisher(PUB) 파일을 PDF로 변환합니다. 여러 파일 지원.",
+    "acceptedFormats": "PUB 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "vsdToPdf": {
+    "name": "VSD를 PDF로",
+    "subtitle": "Microsoft Visio(VSD, VSDX) 파일을 PDF로 변환합니다. 여러 파일 지원.",
+    "acceptedFormats": "VSD, VSDX 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "psdToPdf": {
+    "name": "PSD를 PDF로",
+    "subtitle": "Adobe Photoshop(PSD) 파일을 PDF로 변환합니다. 여러 파일 지원.",
+    "acceptedFormats": "PSD 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "pdfToSvg": {
+    "name": "PDF를 SVG로",
+    "subtitle": "PDF의 각 페이지를 SVG(벡터 그래픽)로 변환하여 어떤 크기에서도 선명하게 볼 수 있습니다."
+  },
+  "extractTables": {
+    "name": "PDF 표 추출",
+    "subtitle": "PDF에서 표를 추출하여 CSV, JSON, Markdown으로 내보냅니다."
+  },
+  "pdfToCsv": {
+    "name": "PDF를 CSV로",
+    "subtitle": "PDF에서 표를 추출하여 CSV로 변환합니다."
+  },
+  "pdfToExcel": {
+    "name": "PDF를 Excel로",
+    "subtitle": "PDF에서 표를 추출하여 Excel(XLSX)로 변환합니다."
+  },
+  "pdfToText": {
+    "name": "PDF를 텍스트로",
+    "subtitle": "PDF에서 텍스트를 추출하여 텍스트 파일(.txt)로 저장합니다. 여러 파일 지원.",
+    "note": "이 도구는 디지털로 생성된 PDF에서만 작동합니다. 스캔 문서나 이미지 기반 PDF는 OCR PDF 도구를 사용해 주세요.",
+    "convertButton": "텍스트 추출"
+  },
+  "digitalSignPdf": {
+    "name": "PDF 디지털 서명",
+    "pageTitle": "PDF 디지털 서명 - 암호화 서명 추가 | BentoPDF",
+    "subtitle": "X.509 인증서를 사용하여 PDF에 암호화 디지털 서명을 추가합니다. PKCS#12(.pfx, .p12) 및 PEM 형식을 지원합니다. 개인키는 브라우저 밖으로 나가지 않습니다.",
+    "certificateSection": "인증서",
+    "uploadCert": "인증서 업로드 (.pfx, .p12)",
+    "certPassword": "인증서 비밀번호",
+    "certPasswordPlaceholder": "인증서 비밀번호 입력",
+    "certInfo": "인증서 정보",
+    "certSubject": "소유자",
+    "certIssuer": "발급자",
+    "certValidity": "유효 기간",
+    "signatureDetails": "서명 세부 정보 (선택 사항)",
+    "reason": "서명 사유",
+    "reasonPlaceholder": "예: 이 문서를 승인합니다",
+    "location": "위치",
+    "locationPlaceholder": "예: 서울, 대한민국",
+    "contactInfo": "연락처",
+    "contactPlaceholder": "예: email@example.com",
+    "applySignature": "디지털 서명 적용",
+    "successMessage": "PDF 서명이 완료되었습니다! 모든 PDF 뷰어에서 서명을 확인할 수 있습니다."
+  },
+  "validateSignaturePdf": {
+    "name": "PDF 서명 검증",
+    "pageTitle": "PDF 서명 검증 - 디지털 서명 확인 | BentoPDF",
+    "subtitle": "PDF의 디지털 서명을 검증합니다. 인증서 유효성 확인, 서명자 정보 조회, 문서 무결성 확인이 가능합니다. 모든 처리는 브라우저에서 이루어집니다."
+  },
+  "emailToPdf": {
+    "name": "이메일을 PDF로",
+    "subtitle": "이메일 파일(EML, MSG)을 PDF로 변환합니다. Outlook 내보내기 및 표준 이메일 형식을 지원합니다.",
+    "acceptedFormats": "EML, MSG 파일",
+    "convertButton": "PDF로 변환"
+  },
+  "fontToOutline": {
+    "name": "폰트 윤곽선 변환",
+    "subtitle": "모든 폰트를 벡터 윤곽선으로 변환하여 어떤 기기에서든 동일하게 표시됩니다."
+  },
+  "deskewPdf": {
+    "name": "PDF 기울기 보정",
+    "subtitle": "기울어진 스캔 페이지를 OpenCV로 자동 보정합니다."
+  },
+  "pdfToWord": {
+    "name": "PDF를 Word로",
+    "subtitle": "PDF를 편집 가능한 Word 문서로 변환합니다."
+  },
+  "extractImages": {
+    "name": "이미지 추출",
+    "subtitle": "PDF에 포함된 모든 이미지를 추출합니다."
+  },
+  "pdfToMarkdown": {
+    "name": "PDF를 Markdown으로",
+    "subtitle": "PDF의 텍스트와 표를 Markdown 형식으로 변환합니다."
+  },
+  "preparePdfForAi": {
+    "name": "AI용 PDF 준비",
+    "subtitle": "RAG/LLM 파이프라인을 위해 PDF를 LlamaIndex JSON으로 추출합니다."
+  },
+  "pdfOcg": {
+    "name": "PDF OCG",
+    "subtitle": "PDF의 OCG(Optional Content Group) 레이어를 보고, 전환하고, 추가하고, 삭제합니다."
+  },
+  "pdfToPdfa": {
+    "name": "PDF를 PDF/A로",
+    "subtitle": "장기 보관을 위해 PDF를 PDF/A로 변환합니다."
+  },
+  "rasterizePdf": {
+    "name": "PDF 래스터화",
+    "subtitle": "PDF를 이미지 기반 PDF로 변환합니다. 레이어를 평탄화하고 선택 가능한 텍스트를 제거합니다."
+  },
+  "pdfWorkflow": {
+    "name": "PDF 워크플로우 빌더",
+    "subtitle": "시각적 노드 편집기로 맞춤형 PDF 처리 파이프라인을 구성합니다.",
+    "nodes": "노드",
+    "searchNodes": "노드 검색...",
+    "run": "실행",
+    "clear": "지우기",
+    "save": "저장",
+    "load": "불러오기",
+    "export": "내보내기",
+    "import": "가져오기",
+    "ready": "준비 완료",
+    "settings": "설정",
+    "processing": "처리 중...",
+    "saveTemplate": "템플릿 저장",
+    "templateName": "템플릿 이름",
+    "templatePlaceholder": "예: 청구서 워크플로우",
+    "cancel": "취소",
+    "loadTemplate": "템플릿 불러오기",
+    "noTemplates": "저장된 템플릿이 없습니다.",
+    "ok": "확인",
+    "workflowCompleted": "워크플로우가 완료되었습니다",
+    "errorDuringExecution": "실행 중 오류 발생",
+    "addNodeError": "워크플로우를 실행하려면 노드를 하나 이상 추가하세요.",
+    "needInputOutput": "워크플로우를 실행하려면 입력 노드와 출력 노드가 각각 하나 이상 필요합니다.",
+    "enterName": "이름을 입력해 주세요.",
+    "templateExists": "같은 이름의 템플릿이 이미 있습니다.",
+    "templateSaved": "템플릿 \"{{name}}\"이(가) 저장되었습니다.",
+    "templateLoaded": "템플릿 \"{{name}}\"을(를) 불러왔습니다.",
+    "failedLoadTemplate": "템플릿을 불러오지 못했습니다.",
+    "noSettings": "이 노드에는 설정할 항목이 없습니다.",
+    "advancedSettings": "고급 설정"
+  }
+}

--- a/src/js/i18n/i18n.ts
+++ b/src/js/i18n/i18n.ts
@@ -19,6 +19,7 @@ export const supportedLanguages = [
   'nl',
   'da',
   'sv',
+  'ko',
 ] as const;
 export type SupportedLanguage = (typeof supportedLanguages)[number];
 
@@ -39,6 +40,7 @@ export const languageNames: Record<SupportedLanguage, string> = {
   nl: 'Nederlands',
   da: 'Dansk',
   sv: 'Svenska',
+  ko: '한국어',
 };
 
 export const getLanguageFromUrl = (): SupportedLanguage => {
@@ -54,7 +56,7 @@ export const getLanguageFromUrl = (): SupportedLanguage => {
   }
 
   const langMatch = path.match(
-    /^\/(en|ar|fr|es|de|zh|zh-TW|vi|tr|id|it|pt|nl|be|da)(?:\/|$)/
+    /^\/(en|ar|fr|es|de|zh|zh-TW|vi|tr|id|it|pt|nl|be|da|ko)(?:\/|$)/
   );
   if (
     langMatch &&
@@ -130,7 +132,7 @@ export const changeLanguage = (lang: SupportedLanguage): void => {
 
   let pagePathWithoutLang = relativePath;
   const langPrefixMatch = relativePath.match(
-    /^\/(en|ar|fr|es|de|zh|zh-TW|vi|tr|id|it|pt|nl|be|da)(\/.*)?$/
+    /^\/(en|ar|fr|es|de|zh|zh-TW|vi|tr|id|it|pt|nl|be|da|ko)(\/.*)?$/
   );
   if (langPrefixMatch) {
     pagePathWithoutLang = langPrefixMatch[2] || '/';
@@ -223,7 +225,7 @@ export const rewriteLinks = (): void => {
     }
 
     const langPrefixRegex = new RegExp(
-      `^(${basePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})?/?(en|ar|fr|es|de|zh|zh-TW|vi|tr|id|it|pt|nl|be|da)(/|$)`
+      `^(${basePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})?/?(en|ar|fr|es|de|zh|zh-TW|vi|tr|id|it|pt|nl|be|da|ko)(/|$)`
     );
     if (langPrefixRegex.test(href)) {
       return;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,7 @@ const SUPPORTED_LANGUAGES = [
   'vi',
   'zh',
   'zh-TW',
+  'ko',
 ] as const;
 const LANG_REGEX = new RegExp(
   `^/(${SUPPORTED_LANGUAGES.join('|')})(?:/(.*))?$`


### PR DESCRIPTION
### Description

Add complete Korean (`ko`) language support for BentoPDF.

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### 🧪 How Has This Been Tested?

**Checklist:**

- [x] Verified output manually
- [x] Tested with relevant sample documents or data

**Expected Results:**

- All UI renders in Korean when visiting `http://localhost:5173/ko/`
- Korean option appears in the language switcher
- `npm run build` generates `dist/ko/` directory

**Actual Results:**

- Homepage, about, contact, FAQ, and tool pages all render correctly in Korean
- Korean is selectable from the footer language switcher
- Static pages generated in `dist/ko/` after build

### Checklist:

- [ ] I have signed the [Contributor License Agreement (CLA)](ICLA.md) or my organization has signed the [Corporate CLA](CCLA.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
