### PR TITLE
fix correct locale path in translation guide, add missing link attributes in footer, fix wasm version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ The setup script loads the Docker image, extracts WASM files, and optionally sta
 **Step 1: Download the WASM packages** (on a machine with internet)
 
 ```bash
-npm pack @bentopdf/pymupdf-wasm@0.11.14
+npm pack @bentopdf/pymupdf-wasm@0.11.16
 npm pack @bentopdf/gs-wasm
 npm pack coherentpdf
 ```

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -118,7 +118,7 @@ Open `public/locales/es/common.json` and translate all the values:
 "inicio": "Inicio"
 ```
 
-Then do the same for `public/locales/fr/tools.json` to translate all tool names and descriptions.
+Then do the same for `public/locales/es/tools.json` to translate all tool names and descriptions.
 
 ### Step 3: Register the Language
 

--- a/src/partials/footer.html
+++ b/src/partials/footer.html
@@ -135,6 +135,8 @@
           </a>
           <a
             href="https://www.instagram.com/thebentopdf/"
+            target="_blank"
+            rel="noopener noreferrer"
             class="text-gray-400 hover:text-indigo-400"
             title="Instagram"
           >
@@ -142,6 +144,8 @@
           </a>
           <a
             href="https://www.linkedin.com/company/bentopdf/"
+            target="_blank"
+            rel="noopener noreferrer"
             class="text-gray-400 hover:text-indigo-400"
             title="LinkedIn"
           >


### PR DESCRIPTION
Fixed a few small things I noticed while reading through the docs and source

**TRANSLATION.md**
- The Spanish translation example references `public/locales/fr/tools.json` on the tools.json step, but the example is for Spanish (`es`), not French. Changed `fr` to `es`.

**src/partials/footer.html**
- Instagram and LinkedIn links were missing `target="_blank"` and `rel="noopener noreferrer"`. The other social links (GitHub, Discord, X) already have these, so this just makes it consistent and avoids potential reverse tabnabbing.

**README.md**
- The manual air-gapped deployment steps reference `@bentopdf/pymupdf-wasm@0.11.14`, but the current default in `.env.production` is `0.11.16`. Updated to match.