### PR TITLE
Add simple mode version to github releases

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -29,8 +29,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build distribution
+      - name: Build full distribution
         run: npm run build
+
+      - name: Build simple distribution
+        run: SIMPLE_MODE=true npm run build
 
       - name: Extract version
         id: version
@@ -38,13 +41,18 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/v}
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
-      - name: Package distribution
+      - name: Package full distribution
         run: npm run package
+
+      - name: Package simple distribution
+        run: BUILD_OUTPUT_DIR=dist-simple npm run package
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist-${{ steps.version.outputs.version }}.zip
+          files: |
+            dist-${{ steps.version.outputs.version }}.zip
+            dist-simple-${{ steps.version.outputs.version }}.zip
           generate_release_notes: true
           draft: false
           prerelease: false

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run build
 
       - name: Build simple distribution
-        run: SIMPLE_MODE=true npm run build
+        run: SIMPLE_MODE=true BUILD_OUTPUT_DIR=dist-simple npm run build
 
       - name: Extract version
         id: version

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-simple
 dist-ssr
 *.local
 .npm-cache

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,7 @@ import eslintConfigPrettier from "eslint-config-prettier";
 
 export default [
     { files: ["**/*.{js,mjs,cjs,ts}"] },
-    { ignores: ["dist/**", "coverage/**", "node_modules/**", "**/.vitepress/cache/**", "public/**/*.min.js"] },
+    { ignores: ["dist/**", "dist-simple/**", "coverage/**", "node_modules/**", "**/.vitepress/cache/**", "public/**/*.min.js"] },
     { languageOptions: { globals: { ...globals.browser, ...globals.node } } },
     pluginJs.configs.recommended,
     ...tseslint.configs.recommended,

--- a/scripts/package-dist.js
+++ b/scripts/package-dist.js
@@ -11,9 +11,11 @@ const version = packageJson.version;
 const buildOutputDirName = process.env.BUILD_OUTPUT_DIR || 'dist';
 console.log(`📦 Building ${buildOutputDirName} folder for version ${version}...`);
 
+const isSimpleMode = (buildOutputDirName === "dist-simple") ? true : false;
+
 // Run the build command
 try {
-  execSync('npm run build', { stdio: 'inherit' });
+  execSync(`SIMPLE_MODE=${isSimpleMode} npm run build`, { stdio: 'inherit' });
   console.log('✅ Build completed successfully');
 } catch (error) {
   console.error('❌ Build failed:', error.message);

--- a/scripts/package-dist.js
+++ b/scripts/package-dist.js
@@ -8,7 +8,8 @@ import { execSync } from 'child_process';
 const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
 const version = packageJson.version;
 
-console.log(`📦 Building dist folder for version ${version}...`);
+const buildOutputDirName = process.env.BUILD_OUTPUT_DIR || 'dist';
+console.log(`📦 Building ${buildOutputDirName} folder for version ${version}...`);
 
 // Run the build command
 try {
@@ -25,12 +26,12 @@ import { pipeline } from 'stream';
 import { promisify } from 'util';
 import archiver from 'archiver';
 
-const distDir = path.resolve('./dist');
-const zipPath = path.resolve(`./dist-${version}.zip`);
+const buildOutputDir = path.resolve('./${buildOutputDirName}');
+const zipPath = path.resolve(`./${buildOutputDirName}-${version}.zip`);
 
 // Check if dist directory exists
-if (!existsSync(distDir)) {
-  console.error('❌ dist directory does not exist. Please run build first.');
+if (!existsSync(buildOutputDir)) {
+  console.error('❌ ${buildOutputDirName} directory does not exist. Please run build first.');
   process.exit(1);
 }
 
@@ -55,7 +56,7 @@ archive.on('error', (err) => {
 archive.pipe(output);
 
 // Append the dist directory to the archive
-archive.directory(distDir, false);
+archive.directory(buildOutputDir, false);
 
 // Finalize the archive
 archive.finalize();

--- a/scripts/package-dist.js
+++ b/scripts/package-dist.js
@@ -26,12 +26,12 @@ import { pipeline } from 'stream';
 import { promisify } from 'util';
 import archiver from 'archiver';
 
-const buildOutputDir = path.resolve('./${buildOutputDirName}');
+const buildOutputDir = path.resolve(`./${buildOutputDirName}`);
 const zipPath = path.resolve(`./${buildOutputDirName}-${version}.zip`);
 
 // Check if dist directory exists
 if (!existsSync(buildOutputDir)) {
-  console.error('❌ ${buildOutputDirName} directory does not exist. Please run build first.');
+  console.error(`❌ ${buildOutputDirName} directory does not exist. Please run build first.`);
   process.exit(1);
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -56,5 +56,5 @@
     }
   },
   "include": ["src", "src/**/*.ts", "public/workers", "vite.config.ts"], // Updated to include all TS files
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "dist-simple"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -83,6 +83,7 @@ function createLanguageMiddleware(isDev: boolean): Connect.NextHandleFunction {
 
     const basePath = getBasePath();
     const [fullPathname, queryString] = req.url.split('?');
+    const outputDir = process.env.BUILD_OUTPUT_DIR || 'dist';
 
     let pathname = fullPathname;
     if (basePath && basePath !== '/' && pathname.startsWith(basePath)) {
@@ -114,7 +115,7 @@ function createLanguageMiddleware(isDev: boolean): Connect.NextHandleFunction {
         if (isDev) {
           req.url = '/index.html' + (queryString ? `?${queryString}` : '');
         } else {
-          const langIndexPath = resolve(__dirname, 'dist', lang, 'index.html');
+          const langIndexPath = resolve(__dirname, outputDir, lang, 'index.html');
           if (fs.existsSync(langIndexPath)) {
             req.url =
               `/${lang}/index.html` + (queryString ? `?${queryString}` : '');
@@ -142,7 +143,7 @@ function createLanguageMiddleware(isDev: boolean): Connect.NextHandleFunction {
         } else {
           const langPagePath = resolve(
             __dirname,
-            'dist',
+            outputDir,
             lang,
             `${pageName}.html`
           );
@@ -162,7 +163,7 @@ function createLanguageMiddleware(isDev: boolean): Connect.NextHandleFunction {
         } else {
           const langPagePath = resolve(
             __dirname,
-            'dist',
+            outputDir,
             lang,
             `${cleanPath}.html`
           );
@@ -367,6 +368,7 @@ export default defineConfig(() => {
       },
     },
     build: {
+      outDir: process.env.BUILD_OUTPUT_DIR || 'dist',
       rollupOptions: {
         input: {
           main:
@@ -582,6 +584,7 @@ export default defineConfig(() => {
           '*.config.ts',
           '**/*.d.ts',
           'dist/',
+          'dist-simple/',
         ],
       },
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
         'node_modules/',
         'src/tests/',
         'dist/',
+        'dist-simple/',
         '*.config.ts',
         '*.config.js',
         '**/*.d.ts',


### PR DESCRIPTION
### Description

Add config to build and release `dist-simple-${version}.zip` in addition to already existing `dist-${version}.zip`.

Fixes #484

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update (deployment instructions?)

### 🧪 How Has This Been Tested?

The new workflow has not been tested yet.

**Checklist:**

- [x] Verified output manually

**Expected Results:**

Upload one additional asset to the Github release.

**Actual Results:**

### Checklist:

- [x] I have signed the [Contributor License Agreement (CLA)](ICLA.md) or my organization has signed the [Corporate CLA](CCLA.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Releases now publish two distribution packages (standard and simplified) as versioned zip assets.
  * Build output directory is configurable so simplified builds are produced separately (dist-simple).
  * Tooling and configs updated to ignore/exclude the simplified output from linting, type-checking, and coverage.
  * Multi-arch container build and publish steps were removed from the release workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->