### PR TITLE
fix: in bookmarks editor focus cancel- or ok-button for opened confirm and alert modals 

### DIFF
--- a/src/js/logic/bookmark-pdf.ts
+++ b/src/js/logic/bookmark-pdf.ts
@@ -822,7 +822,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 function showConfirmModal(message: string): Promise<boolean> {
   return new Promise((resolve) => {
-    const previousActiveEl = document.activeElement as HTMLButtonElement | null;
+    const previousActiveEl = document.activeElement as HTMLElement | null;
     const overlay = document.createElement('div');
     overlay.className = 'modal-overlay';
 
@@ -875,7 +875,7 @@ function showConfirmModal(message: string): Promise<boolean> {
 
 function showAlertModal(title: string, message: string): Promise<boolean> {
   return new Promise((resolve) => {
-    const previousActiveEl = document.activeElement as HTMLButtonElement | null;
+    const previousActiveEl = document.activeElement as HTMLElement | null;
     const overlay = document.createElement('div');
     overlay.className = 'modal-overlay';
 


### PR DESCRIPTION
### Description

When pressing `Enter` to add a new bookmark and the new bookmark title is empty, a modal appears, which informs about the correct usage ("Please enter title"). But this modal or the "ok"-Button are not focused, so the user must use the mouse to close it. If the button would be focused, it could be ergonomically closed with `Enter` or `Space`.

There are three types of modals on the bookmark tool page, `showInputModal(...)`, `showConfirmModal(...)` and `showAlertModal(...)`. While `showInputModal(...)` has a mechanism to focus the first input element of the modal, the others have no input elements, only text and buttons and nothing is focused.

I suggest the following changes for the latter two modals:
**when opening the modal**
- remember previously focused element
- set the ok or cancel button as the focused element

**when closing the modal**
- restore the focus to the previously focused element

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### 🧪 How Has This Been Tested?

- open bookmark edit tool
- select new bookmark title input field
- while there is no text, press enter repeatedly
  - this should open and close the modal and not open more and more modals as before
- close the modal
  - the bookmark title input field should be selected

- other modals can be tested via clicking the "delete all" or "reset" buttons
  - should select "ok" or "cancel" button (not "confirm")

**Checklist:**

- [x] Verified output manually
- [x] Tested with relevant sample documents or data
- [ ] Wrote Vite Test Case (if applicable)

**Expected Results:**

- after opening a modal, the "ok" or "cancel" button is selected
- after closing the modal, the previous active element is focused (if it still exists)

**Actual Results:** (If this is supposed to mean results of the tests without the fix, I would not place it here, but before the contributor presents their solution/changes. For me this section reads as, "I tried to solve it, but did not quite get there. Here are the things that are still unsolved: ...", which is probably not that common.)

- after opening a modal, the "ok" or "cancel" button is selected
- after closing the modal, the previous active element is focused (if it still exists)

### Checklist:

- [x] I have signed the [Contributor License Agreement (CLA)](ICLA.md) or my organization has signed the [Corporate CLA](CCLA.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard accessibility in modal dialogs: when a confirm or alert modal opens focus moves to the primary action button, focus is restored to the element that was active before the modal opened when the modal closes, and all modal-close paths (buttons and overlay click) now correctly restore focus for a smoother keyboard and assistive‑technology experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->