### PR TITLE
fix(md to pdf): restore mermaid flowchart node labels. Fixes #738

### DIFF
--- a/src/js/utils/markdown-editor.ts
+++ b/src/js/utils/markdown-editor.ts
@@ -299,6 +299,7 @@ export class MarkdownEditor {
         startOnLoad: false,
         theme: 'default',
         securityLevel: 'strict',
+        htmlLabels: false,
         fontFamily:
           '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
       });
@@ -717,9 +718,10 @@ export class MarkdownEditor {
 
           const wrapper = document.createElement('div');
           wrapper.className = 'mermaid-diagram';
-          wrapper.innerHTML = DOMPurify.sanitize(svg, {
-            USE_PROFILES: { svg: true, svgFilters: true },
-          });
+          // Mermaid already sanitizes SVG at securityLevel: 'strict' (including
+          // foreignObject HTML labels). A second DOMPurify pass with the SVG-only
+          // profile strips those labels and leaves empty flowchart nodes.
+          wrapper.innerHTML = svg;
 
           pre.replaceWith(wrapper);
         } catch (error) {

--- a/src/tests/markdown-mermaid.test.ts
+++ b/src/tests/markdown-mermaid.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import DOMPurify, { type Config } from 'dompurify';
+
+// Broken when applied after mermaid.render() — strips foreignObject labels.
+const BENTOPDF_SVG_ONLY_SANITIZE_OPTIONS: Config = {
+  USE_PROFILES: { svg: true, svgFilters: true },
+};
+
+/** Matches Mermaid 11 strict-mode output sanitization in mermaid.render(). */
+const MERMAID_STRICT_SVG_SANITIZE_OPTIONS: Config = {
+  ADD_TAGS: ['foreignobject'],
+  ADD_ATTR: ['dominant-baseline'],
+  HTML_INTEGRATION_POINTS: { foreignobject: true },
+};
+
+describe('Markdown to PDF — Mermaid SVG sanitization', () => {
+  it('documents that SVG-only DOMPurify strips foreignObject labels (regression guard)', () => {
+    const htmlLabelsSvg = `<svg xmlns="http://www.w3.org/2000/svg">
+      <g class="node">
+        <rect width="100" height="50"/>
+        <foreignObject width="100" height="50">
+          <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex">
+            <span>Start</span>
+          </div>
+        </foreignObject>
+      </g>
+    </svg>`;
+
+    const clean = DOMPurify.sanitize(
+      htmlLabelsSvg,
+      BENTOPDF_SVG_ONLY_SANITIZE_OPTIONS
+    );
+
+    expect(clean).not.toContain('Start');
+    expect(clean).not.toContain('foreignObject');
+  });
+
+  it('preserves foreignObject labels with Mermaid strict sanitizer settings', () => {
+    const htmlLabelsSvg = `<svg xmlns="http://www.w3.org/2000/svg">
+      <foreignObject width="120" height="40">
+        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex">
+          <span class="nodeLabel">Start</span>
+        </div>
+      </foreignObject>
+    </svg>`;
+
+    const clean = DOMPurify.sanitize(
+      htmlLabelsSvg,
+      MERMAID_STRICT_SVG_SANITIZE_OPTIONS
+    );
+
+    expect(clean).toContain('Start');
+    expect(clean).toContain('foreignObject');
+    expect(clean).toContain('nodeLabel');
+  });
+
+  it('preserves native SVG text labels under SVG-only profile', () => {
+    const svgTextLabels = `<svg xmlns="http://www.w3.org/2000/svg">
+      <g class="node">
+        <rect width="100" height="50"/>
+        <text x="10" y="20" fill="#333">Start</text>
+      </g>
+    </svg>`;
+
+    const clean = DOMPurify.sanitize(
+      svgTextLabels,
+      BENTOPDF_SVG_ONLY_SANITIZE_OPTIONS
+    );
+
+    expect(clean).toContain('Start');
+    expect(clean).toContain('<text');
+  });
+});


### PR DESCRIPTION

Mermaid flowcharts in **Markdown to PDF** rendered with empty nodes (boxes and arrows only, no label text) in preview and print, in both light and dark mode.

**Root cause:** `mermaid.render()` already sanitizes SVG when `securityLevel: 'strict'` (including `foreignObject` HTML labels). The editor then ran **DOMPurify again** with `USE_PROFILES: { svg: true }`, which strips entire `foreignObject` subtrees and removes all node labels.

**Fix:**
- Use Mermaid’s SVG directly in the preview (`wrapper.innerHTML = svg`) instead of a second DOMPurify pass.
- Set `htmlLabels: false` in `mermaid.initialize()` as an extra safeguard for SVG text labels.
- Add `src/tests/markdown-mermaid.test.ts` to document SVG-only vs Mermaid strict sanitizer behavior.

**Dependencies:** None.

Fixes #738

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

**Checklist:**

- [x] Verified output manually
- [x] Tested with relevant sample documents or data
- [x] Wrote Vite Test Case (if applicable)

**Steps:**
1. `npm run test:run` - All test cases passed.
2. `npm run dev` → open `http://localhost:5173/markdown-to-pdf.html`.
3. Used default sample flowchart mentioned in #738 
4. Toggled light/dark theme — labels visible in both.
5. Export PDF / print preview — labels included.

**Expected results:**
- Flowchart node and edge labels visible in preview.
- No regression in XSS handling (Mermaid strict mode still sanitizes before insert).

**Actual results:**
- Labels render correctly in preview, light/dark mode, and print.
- New regression tests pass; full local test suite passes.

### Checklist:

- [x] I have signed the [Contributor License Agreement (CLA)](ICLA.md) or my organization has signed the [Corporate CLA](CCLA.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<img width="1658" height="1088" alt="Screenshot 2026-06-04 at 5 20 06 PM" src="https://github.com/user-attachments/assets/36277ca0-9d12-481a-913d-37ad2230aaf3" />
<img width="1542" height="957" alt="Screenshot 2026-06-04 at 5 20 04 PM" src="https://github.com/user-attachments/assets/89a4d53a-170a-45fd-b068-3d243928c57a" />
