### PR TITLE
feat: allow configuring internal port via BENTOPDF_PORT

### DIFF
--- a/docs/self-hosting/docker.md
+++ b/docs/self-hosting/docker.md
@@ -115,6 +115,8 @@ docker run -d -p 3000:8080 bentopdf:custom
 | `VITE_BRAND_LOGO`                    | Logo path relative to `public/`                                                                                              | `images/favicon-no-bg.svg`                                     |
 | `VITE_FOOTER_TEXT`                   | Custom footer/copyright text                                                                                                 | `© 2026 BentoPDF. All rights reserved.`                        |
 | `DISABLE_TOOLS`                      | Comma-separated tool IDs to hide                                                                                             | _(empty; all tools enabled)_                                   |
+| `BENTOPDF_PORT`                      | Nginx listen port inside the container                                                                                           | `8080`                                   |
+| `PORT`                      | Legacy fallback port environment variable                                                                                          | `8080`                                   |
 
 WASM module URLs are pre-configured with CDN defaults — all advanced features work out of the box. Override these for air-gapped or self-hosted deployments.
 

--- a/docs/self-hosting/docker.md
+++ b/docs/self-hosting/docker.md
@@ -118,6 +118,11 @@ docker run -d -p 3000:8080 bentopdf:custom
 | `BENTOPDF_PORT`                      | Nginx listen port inside the container                                                                                           | `8080`                                   |
 | `PORT`                      | Legacy fallback port environment variable                                                                                          | `8080`                                   |
 
+
+**Port resolution priority**: `BENTOPDF_PORT` → `PORT` → `8080`
+
+Use `BENTOPDF_PORT` to avoid conflicts with other services that use `PORT`.
+
 WASM module URLs are pre-configured with CDN defaults — all advanced features work out of the box. Override these for air-gapped or self-hosted deployments.
 
 ### Content-Security-Policy

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ chown -R "$PUID:$PGID" \
     /usr/share/nginx/html \
     /etc/nginx/nginx.conf
 
-PORT=${PORT:-8080}
+PORT=${BENTOPDF_PORT:-${PORT:-8080}}
 if [ "$PORT" != "8080" ]; then
     echo "Changing Nginx listen port to $PORT"
     sed -i "s/listen 8080/listen $PORT/g; s/listen \[::\]:8080/listen [::]:$PORT/g" /etc/nginx/nginx.conf

--- a/nginx-ipv6.sh
+++ b/nginx-ipv6.sh
@@ -9,7 +9,7 @@ entrypoint_log() {
     fi
 }
 
-PORT=${PORT:-8080}
+PORT=${BENTOPDF_PORT:-${PORT:-8080}}
 if [ "$PORT" != "8080" ]; then
   entrypoint_log "Changing Nginx listen port to $PORT"
   sed -i "s/listen 8080/listen $PORT/g; s/listen \[::\]:8080/listen [::]:$PORT/g" /etc/nginx/nginx.conf


### PR DESCRIPTION
This PR introduces a dedicated `BENTOPDF_PORT` environment variable to the container's Nginx initialization script, allowing operators to explicitly configure the internal listening port. 

**Motivation and Context:**
When running BentoPDF in certain homelab configurations—especially when utilizing host network routing namespaces (`network_mode: host`) or rootless Podman setups—relying on a generic `PORT` variable can lead to environmental variable bleeding or port conflicts with other running container services. Providing a scoped `BENTOPDF_PORT` variable avoids conflict while making orchestration manifests clearer to maintain.

**Dependencies:**
None. This is an isolated adjustment to `nginx-ipv6.sh`.

Fixes # n/a

**Type of Change**
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**
I manually verified the environment variable mapping natively within the shell script framework. 

**Checklist:**
- [x] Verified output manually
- [ ] Tested with relevant sample documents or data
- [ ] Wrote Vite Test Case (if applicable)

**Expected Results:**
When `BENTOPDF_PORT` is declared, the container initialization sequence should intercept the variable and dynamically re-bind the Nginx listener to the specified value. If left empty, it should fall back to `PORT` or default to `8080`.

**Actual Results:**
The configuration successfully parsed the custom environment entry block dynamically using nested bash evaluation patterns (`${BENTOPDF_PORT:-${PORT:-8080}}`) without generating logic exceptions.

**Checklist**
- [ ] I have signed the Contributor License Agreement (CLA) or my organization has signed the Corporate CLA
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code is self-explanatory and maintains existing project standards
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Port resolution updated to prefer BENTOPDF_PORT, then fall back to PORT, then to 8080; startup scripts and runtime behavior updated to use this priority to avoid port conflicts while preserving existing defaults.
* **Documentation**
  * Self-hosting Docker/Podman guide updated to document the new BENTOPDF_PORT and legacy PORT environment variables, their defaults, and recommended usage to prevent conflicts with other services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->