### PR TITLE
(Feature) Add extraVolumes and extraVolumeMounts in chart Helm

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -65,6 +65,9 @@ spec:
               mountPath: /var/cache/nginx
             - name: nginx-run
               mountPath: /var/run
+            {{- if .Values.extraVolumeMounts }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
       volumes:
         - name: nginx-tmp
           emptyDir: {}
@@ -72,3 +75,6 @@ spec:
           emptyDir: {}
         - name: nginx-run
           emptyDir: {}
+        {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -86,3 +86,7 @@ readinessProbe:
   httpGet:
     path: /
     port: http
+
+extraVolumes: []
+
+extraVolumeMounts: []


### PR DESCRIPTION
### Description

Add extraVolumes and extraVolumeMounts in chart Helm.
This feature would allow you to override the /usr/share/nginx/html/config.json file using a ConfigMap.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### 🧪 How Has This Been Tested?

**Checklist:**

- [x] Verified output manually

**Expected Results:**

- A ConfigMap is used and mounted in a file within a folder.

### Checklist:

- [x] I have read the CLA Document and I hereby sign the CLA
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom storage volumes and mounts in deployment configuration. Users can now extend storage definitions through new configuration parameters for specialized storage requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->