### PR TITLE
fix: grammar typo, redundant variable, unused shortcut value

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ BentoPDF offers a comprehensive suite of tools to handle all your PDF needs.
 | **View PDF**                 | A powerful, integrated PDF viewer.                                                                      |
 | **Alternate & Mix Pages**    | Merge pages by alternating pages from each PDF. Preserves Bookmarks.                                    |
 | **Posterize PDF**            | Split a PDF into multiple smaller pages for print.                                                      |
-| **PDF Multi Tool**           | Merge, Split, Organize, Delete, Rotate, Add Blank Pages, Extract and Duplicate in an unified interface. |
+| **PDF Multi Tool**           | Merge, Split, Organize, Delete, Rotate, Add Blank Pages, Extract and Duplicate in a unified interface. |
 | **PDF Booklet**              | Rearrange pages for double-sided booklet printing. Fold and staple to create a booklet.                 |
 | **Add Attachments**          | Embed one or more files into your PDF.                                                                  |
 | **Extract Attachments**      | Extract all embedded files from PDF(s) as a ZIP.                                                        |

--- a/public/locales/en/tools.json
+++ b/public/locales/en/tools.json
@@ -13,7 +13,7 @@
   "convertToPdf": "Convert to PDF",
   "pdfMultiTool": {
     "name": "PDF Multi Tool",
-    "subtitle": "Merge, Split, Organize, Delete, Rotate, Add Blank Pages, Extract and Duplicate in an unified interface."
+    "subtitle": "Merge, Split, Organize, Delete, Rotate, Add Blank Pages, Extract and Duplicate in a unified interface."
   },
   "mergePdf": {
     "name": "Merge PDF",

--- a/src/js/config/tools.ts
+++ b/src/js/config/tools.ts
@@ -15,7 +15,7 @@ const baseCategories = [
         name: 'PDF Multi Tool',
         icon: 'ph-pencil-ruler',
         subtitle:
-          'Merge, Split, Organize, Delete, Rotate, Add Blank Pages, Extract and Duplicate in an unified interface.',
+          'Merge, Split, Organize, Delete, Rotate, Add Blank Pages, Extract and Duplicate in a unified interface.',
       },
       {
         href: import.meta.env.BASE_URL + 'merge-pdf.html',

--- a/src/js/logic/compress-pdf-page.ts
+++ b/src/js/logic/compress-pdf-page.ts
@@ -345,9 +345,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const level = (
       document.getElementById('compression-level') as HTMLSelectElement
     ).value;
-    const algorithm = (
-      document.getElementById('compression-algorithm') as HTMLSelectElement
-    ).value;
     const convertToGrayscale =
       (document.getElementById('convert-to-grayscale') as HTMLInputElement)
         ?.checked ?? false;

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -1105,7 +1105,7 @@ const init = async () => {
           // If the user releases a modifier without pressing a main key, revert to saved
           const key = e.key.toLowerCase();
           if (['control', 'shift', 'alt', 'meta'].includes(key)) {
-            const currentSaved = ShortcutsManager.getShortcut(toolId);
+            input.value = ShortcutsManager.getShortcut(toolId) || '';
           }
         };
 


### PR DESCRIPTION
A few small things:

- "in an unified interface" should be "in a unified interface" — "unified" starts with a consonant /j/ sound so it takes "a" not "an". Fixed in tools.ts, tools.json, and README.md.
- compress-pdf-page.ts had the same \`const algorithm\` declared twice — once at the top of the function and again identically inside the try block, making the first one dead code. Removed the redundant outer declaration.
- the keyboard shortcut \`onkeyup\` handler was reading the saved shortcut with \`ShortcutsManager.getShortcut(toolId)\` but never actually using the value — the input wasn't being reverted when modifier keys were released. Now it sets the value back properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the wording for the “PDF Multi Tool” description across the app and documentation.
  * Improved how shortcut inputs refresh after modifier keys are released, so saved shortcuts display more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->