### PR TITLE
fix: polyfill Map.prototype.getOrInsertComputed to stop PDF.js render crash

### DIFF
--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -1,3 +1,4 @@
+import './utils/map-upsert-polyfill.js';
 import { categories } from './config/tools.js';
 import { dom, switchView, hideAlert } from './ui.js';
 import { ShortcutsManager } from './logic/shortcuts.js';

--- a/src/js/utils/map-upsert-polyfill.ts
+++ b/src/js/utils/map-upsert-polyfill.ts
@@ -1,0 +1,47 @@
+type MapPrototypeWithUpsert = typeof Map.prototype & {
+  getOrInsert?: (key: unknown, value: unknown) => unknown;
+  getOrInsertComputed?: (
+    key: unknown,
+    callback: (key: unknown) => unknown
+  ) => unknown;
+};
+
+const mapPrototype = Map.prototype as MapPrototypeWithUpsert;
+const mapHas = Map.prototype.has;
+const mapGet = Map.prototype.get;
+const mapSet = Map.prototype.set;
+
+if (typeof mapPrototype.getOrInsert !== 'function') {
+  Object.defineProperty(mapPrototype, 'getOrInsert', {
+    configurable: true,
+    writable: true,
+    value: function getOrInsert(key: unknown, value: unknown) {
+      if (mapHas.call(this, key)) return mapGet.call(this, key);
+      mapSet.call(this, key, value);
+      return value;
+    },
+  });
+}
+
+if (typeof mapPrototype.getOrInsertComputed !== 'function') {
+  Object.defineProperty(mapPrototype, 'getOrInsertComputed', {
+    configurable: true,
+    writable: true,
+    value: function getOrInsertComputed(
+      key: unknown,
+      callback: (key: unknown) => unknown
+    ) {
+      const hasKey = mapHas.call(this, key);
+      if (typeof callback !== 'function') {
+        throw new TypeError('callback must be a function');
+      }
+      if (hasKey) return mapGet.call(this, key);
+
+      const value = callback(key);
+      mapSet.call(this, key, value);
+      return value;
+    },
+  });
+}
+
+export {};

--- a/src/tests/map-upsert-polyfill.test.ts
+++ b/src/tests/map-upsert-polyfill.test.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type MapWithUpsert<K, V> = Map<K, V> & {
+  getOrInsert(key: K, value: V): V;
+  getOrInsertComputed(key: K, callback: (key: K) => V): V;
+};
+
+const getOrInsertDescriptor = Object.getOwnPropertyDescriptor(
+  Map.prototype,
+  'getOrInsert'
+);
+const getOrInsertComputedDescriptor = Object.getOwnPropertyDescriptor(
+  Map.prototype,
+  'getOrInsertComputed'
+);
+
+const restoreMethod = (
+  name: 'getOrInsert' | 'getOrInsertComputed',
+  descriptor: PropertyDescriptor | undefined
+) => {
+  if (descriptor) {
+    Object.defineProperty(Map.prototype, name, descriptor);
+  } else {
+    Reflect.deleteProperty(Map.prototype, name);
+  }
+};
+
+const importPolyfill = async () => {
+  await import('../js/utils/map-upsert-polyfill');
+};
+
+describe('Map upsert polyfill', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreMethod('getOrInsert', getOrInsertDescriptor);
+    restoreMethod('getOrInsertComputed', getOrInsertComputedDescriptor);
+    vi.resetModules();
+  });
+
+  it('preserves an existing native implementation', async () => {
+    const nativeImplementation = vi.fn();
+    Object.defineProperty(Map.prototype, 'getOrInsertComputed', {
+      configurable: true,
+      writable: true,
+      value: nativeImplementation,
+    });
+
+    await importPolyfill();
+
+    expect(
+      Object.getOwnPropertyDescriptor(Map.prototype, 'getOrInsertComputed')
+        ?.value
+    ).toBe(nativeImplementation);
+  });
+
+  it('installs getOrInsertComputed when it is missing', async () => {
+    Reflect.deleteProperty(Map.prototype, 'getOrInsertComputed');
+
+    await importPolyfill();
+
+    const descriptor = Object.getOwnPropertyDescriptor(
+      Map.prototype,
+      'getOrInsertComputed'
+    );
+    expect(typeof descriptor?.value).toBe('function');
+    expect(descriptor?.enumerable).toBe(false);
+  });
+
+  it('returns an existing value without invoking the callback', async () => {
+    Reflect.deleteProperty(Map.prototype, 'getOrInsertComputed');
+    await importPolyfill();
+    const map = new Map([['key', 'cached']]) as MapWithUpsert<string, string>;
+    const callback = vi.fn(() => 'computed');
+
+    expect(map.getOrInsertComputed('key', callback)).toBe('cached');
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('computes, stores, and returns a missing value', async () => {
+    Reflect.deleteProperty(Map.prototype, 'getOrInsertComputed');
+    await importPolyfill();
+    const map = new Map<string, string>() as MapWithUpsert<string, string>;
+    const callback = vi.fn((key: string) => `${key}-value`);
+
+    expect(map.getOrInsertComputed('missing', callback)).toBe('missing-value');
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledWith('missing');
+    expect(map.get('missing')).toBe('missing-value');
+  });
+
+  it('installs getOrInsert with matching get-or-insert behavior', async () => {
+    Reflect.deleteProperty(Map.prototype, 'getOrInsert');
+    await importPolyfill();
+    const map = new Map([['existing', 'cached']]) as MapWithUpsert<
+      string,
+      string
+    >;
+
+    expect(map.getOrInsert('existing', 'replacement')).toBe('cached');
+    expect(map.getOrInsert('missing', 'inserted')).toBe('inserted');
+    expect(map.get('missing')).toBe('inserted');
+  });
+
+  it('loads before PDF.js so render can use the methods', () => {
+    const mainSource = readFileSync(
+      new URL('../js/main.ts', import.meta.url),
+      'utf8'
+    );
+    const polyfillImport = "import './utils/map-upsert-polyfill.js';";
+    const pdfjsImport = "import * as pdfjsLib from 'pdfjs-dist';";
+
+    expect(mainSource.startsWith(polyfillImport)).toBe(true);
+    expect(mainSource.indexOf(polyfillImport)).toBeLessThan(
+      mainSource.indexOf(pdfjsImport)
+    );
+  });
+});


### PR DESCRIPTION
### Description

Fetched `pdfjs-dist@5.5.207` (the version currently resolved by `package-lock.json` under the `^5.4.624` caret range) from unpkg and confirmed the crash site directly: `PDFPageProxy.render()` unconditionally calls `this._transport.getOptionalContentConfig(renderingIntent)`, which calls `#cacheSimpleMethod("GetOptionalContentConfig")`, which calls `this.#methodPromises.getOrInsertComputed(name, () => ...)` (`build/pdf.mjs` line ~15510) - an exact match for the minified stack trace in the issue (`this.#e.getOrInsertComputed(t,()=>this.messageHandler.sendWithPromise(t,e))`). `render()` also calls `this._intentStates.getOrInsertComputed(cacheKey, makeObj)` on the same code path. `Map.prototype.getOrInsertComputed` is a very recent TC39 "Upsert" built-in that `pdfjs-dist` now relies on unconditionally, without feature-detection or a bundled polyfill - so it crashes in any browser/engine that lacks native support, which explains why it fails identically across Safari 18.6 and the reporter's Chrome build, and also explains the second, independently-reported crash in `pdf-multi-tool` (any tool calling `pdfJsPage.render()` is affected, not just OCR).

`/ocr-pdf.html` crashes on every PDF with `TypeError: this.#e.getOrInsertComputed is not a function`, thrown from PDF.js's `render()` -> `getOptionalContentConfig()` path (`main-*.js` chunk). Reproduced on both Safari 18.6 and Chrome latest, on a self-hosted Docker deployment (`ghcr.io/alam00000/bentopdf-simple:latest`). The reporter speculated a worker/main-thread PDF.js version mismatch, but `src/js/main.ts` sets `GlobalWorkerOptions.workerSrc` via Vite's `new URL('pdfjs-dist/build/pdf.worker.min.mjs', import.meta.url)`, which always resolves to the same installed `pdfjs-dist` package as the main thread - so worker/main are in lockstep, ruling that theory out. A second reporter (`BlackWolfWoof`, 2026-07-12) hit an apparently related crash in the unrelated `pdf-multi-tool`, which also calls `pdfJsPage.render({ canvasContext, ...

Fixes #662

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### 🧪 How Has This Been Tested?

Native support present: if `Map.prototype.getOrInsertComputed` already exists (feature-detected via `Map.prototype.hasOwnProperty` or `typeof` check), the polyfill module does not overwrite it - assert the original function reference is unchanged after import.
Polyfill installs when missing: delete/stub `Map.prototype.getOrInsertComputed` before import (or test the standalone install function against a plain object shaped like a Map), then call it on a `Map` instance and assert it exists as a function afterward.
Existing key: `map.getOrInsertComputed(key, cb)` on a Map that already has `key` returns the existing value and never invokes `cb`.
Missing key: `map.getOrInsertComputed(key, cb)` on a Map without `key` invokes `cb(key)` exactly once, stores the result under `key`, and returns it.
Regression guard: a lightweight smoke test (or comment referencing the OCR/PDF.js path) documenting that this polyfill is what unblocks `pdfjsPage.render()` in `getOptionalContentConfig`, so a future removal of the import doesn't silently reintroduce the crash.

### Checklist:

- [x] I have signed the [Contributor License Agreement (CLA)](ICLA.md) or my organization has signed the [Corporate CLA](CCLA.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Added support for modern `Map` convenience methods in environments where they are unavailable.
  * Preserves existing native implementations when supported.

* **Bug Fixes**
  * Ensures map values can be retrieved or created consistently during application startup.
  * Added validation for computed value callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->