### PR TITLE
feat(compare): whole-document mode with page-fixed content handling

### DIFF
--- a/src/js/compare/config.ts
+++ b/src/js/compare/config.ts
@@ -37,3 +37,13 @@ export const VISUAL_DIFF = {
 } as const;
 
 export const COMPARE_CACHE_MAX_SIZE = 50;
+
+export const HEADER_FOOTER_ZONE = 0.12;
+
+export const COMPARE_FURNITURE = {
+  FONT_SCALE_OUTLIER: 2.2,
+  ROTATION_TOLERANCE_DEG: 12,
+  REPEAT_PAGE_FRACTION: 0.6,
+  REPEAT_MIN_PAGES: 3,
+  POSITION_QUANTIZE: 12,
+} as const;

--- a/src/js/compare/engine/compare-content.ts
+++ b/src/js/compare/engine/compare-content.ts
@@ -6,8 +6,7 @@ import type {
   CompareRectangle,
   CompareTextChange,
 } from '../types.ts';
-
-const HEADER_FOOTER_ZONE = 0.12;
+import { HEADER_FOOTER_ZONE } from '../config.ts';
 
 export function classifyChangeCategory(
   change: CompareTextChange,
@@ -24,7 +23,7 @@ export function classifyChangeCategory(
   return 'text';
 }
 
-function isHeaderFooterZone(
+export function isHeaderFooterZone(
   rects: CompareRectangle[],
   pageHeight: number
 ): boolean {

--- a/src/js/compare/engine/compare-document.ts
+++ b/src/js/compare/engine/compare-document.ts
@@ -1,0 +1,233 @@
+import type {
+  ComparePageModel,
+  ComparePagePair,
+  ComparePageResult,
+  CompareChangeSummary,
+  CompareTextChange,
+  CompareTextItem,
+} from '../types.ts';
+import {
+  classifyChangeCategory,
+  diffAnnotations,
+  diffImages,
+  buildCategorySummary,
+  isHeaderFooterZone,
+} from './compare-content.ts';
+import { comparePageModels } from './compare-page-models.ts';
+import { diffTextRuns } from './diff-text-runs.ts';
+import { itemPositionKey, repeatedItemKeys } from './fixed-layer.ts';
+
+export interface DocumentPagePair {
+  pair: ComparePagePair;
+  left: ComparePageModel | null;
+  right: ComparePageModel | null;
+}
+
+function tagItems(
+  items: CompareTextItem[],
+  pageNumber: number
+): CompareTextItem[] {
+  return items.map((item) => ({ ...item, pageNumber }));
+}
+
+function documentRepeatedKeys(
+  pages: DocumentPagePair[],
+  side: 'left' | 'right'
+): Set<string> {
+  const models = pages
+    .map((entry) => entry[side])
+    .filter((model): model is ComparePageModel => model !== null);
+  return repeatedItemKeys(models);
+}
+
+function isFixedItem(
+  item: CompareTextItem,
+  pageHeight: number,
+  repeatedKeys: Set<string>
+): boolean {
+  return (
+    item.layer === 'background' ||
+    isHeaderFooterZone([item.rect], pageHeight) ||
+    repeatedKeys.has(itemPositionKey(item))
+  );
+}
+
+function splitPageItems(
+  model: ComparePageModel,
+  repeatedKeys: Set<string>,
+  detectFixed: boolean
+): { flow: CompareTextItem[]; fixed: CompareTextItem[] } {
+  const flow: CompareTextItem[] = [];
+  const fixed: CompareTextItem[] = [];
+  for (const item of model.textItems) {
+    if (detectFixed && isFixedItem(item, model.height, repeatedKeys)) {
+      fixed.push(item);
+    } else {
+      flow.push(item);
+    }
+  }
+  return { flow, fixed };
+}
+
+export function collectDocumentItems(
+  pages: DocumentPagePair[],
+  detectFixed = true
+): {
+  beforeItems: CompareTextItem[];
+  afterItems: CompareTextItem[];
+} {
+  const leftRepeated = detectFixed
+    ? documentRepeatedKeys(pages, 'left')
+    : new Set<string>();
+  const rightRepeated = detectFixed
+    ? documentRepeatedKeys(pages, 'right')
+    : new Set<string>();
+  const beforeItems: CompareTextItem[] = [];
+  const afterItems: CompareTextItem[] = [];
+
+  for (const { left, right } of pages) {
+    if (!left || !right) continue;
+    beforeItems.push(
+      ...tagItems(
+        splitPageItems(left, leftRepeated, detectFixed).flow,
+        left.pageNumber
+      )
+    );
+    afterItems.push(
+      ...tagItems(
+        splitPageItems(right, rightRepeated, detectFixed).flow,
+        right.pageNumber
+      )
+    );
+  }
+
+  return { beforeItems, afterItems };
+}
+
+function summarizeChanges(changes: CompareTextChange[]): CompareChangeSummary {
+  const summary: CompareChangeSummary = {
+    added: 0,
+    removed: 0,
+    modified: 0,
+    moved: 0,
+    styleChanged: 0,
+  };
+  for (const change of changes) {
+    if (change.type === 'added') summary.added += 1;
+    else if (change.type === 'removed') summary.removed += 1;
+    else if (change.type === 'modified') summary.modified += 1;
+    else if (change.type === 'moved') summary.moved += 1;
+    else if (change.type === 'style-changed') summary.styleChanged += 1;
+  }
+  return summary;
+}
+
+export function buildDocumentResults(
+  pages: DocumentPagePair[],
+  diff: { changes: CompareTextChange[]; summary: CompareChangeSummary },
+  detectFixed = true
+): Map<number, ComparePageResult> {
+  const results = new Map<number, ComparePageResult>();
+  const pairByLeftPage = new Map<number, DocumentPagePair>();
+  const pairByRightPage = new Map<number, DocumentPagePair>();
+  const bucketedChanges = new Map<number, CompareTextChange[]>();
+  const leftRepeated = detectFixed
+    ? documentRepeatedKeys(pages, 'left')
+    : new Set<string>();
+  const rightRepeated = detectFixed
+    ? documentRepeatedKeys(pages, 'right')
+    : new Set<string>();
+
+  for (const entry of pages) {
+    const { pair, left, right } = entry;
+    if (left && right) {
+      pairByLeftPage.set(left.pageNumber, entry);
+      pairByRightPage.set(right.pageNumber, entry);
+      bucketedChanges.set(pair.pairIndex, []);
+    } else {
+      const result = comparePageModels(left, right);
+      result.confidence = pair.confidence;
+      results.set(pair.pairIndex, result);
+    }
+  }
+
+  const pushInto = (
+    entry: DocumentPagePair | undefined,
+    change: CompareTextChange
+  ) => {
+    if (!entry) return;
+    bucketedChanges.get(entry.pair.pairIndex)?.push(change);
+  };
+
+  for (const change of diff.changes) {
+    const before =
+      change.beforePage != null
+        ? pairByLeftPage.get(change.beforePage)
+        : undefined;
+    const after =
+      change.afterPage != null
+        ? pairByRightPage.get(change.afterPage)
+        : undefined;
+
+    if (change.type === 'added') {
+      pushInto(after, change);
+    } else if (change.type === 'removed') {
+      pushInto(before, change);
+    } else if (
+      before &&
+      after &&
+      before.pair.pairIndex === after.pair.pairIndex
+    ) {
+      pushInto(before, change);
+    } else {
+      pushInto(before, { ...change, id: `${change.id}-b`, afterRects: [] });
+      pushInto(after, { ...change, id: `${change.id}-a`, beforeRects: [] });
+    }
+  }
+
+  for (const entry of pages) {
+    const { pair, left, right } = entry;
+    if (!left || !right) continue;
+
+    const pageHeight = Math.max(left.height, right.height);
+    const fixedChanges = diffTextRuns(
+      splitPageItems(left, leftRepeated, detectFixed).fixed,
+      splitPageItems(right, rightRepeated, detectFixed).fixed
+    ).changes.map((change) => ({ ...change, id: `fixed-${change.id}` }));
+    const textChanges = [
+      ...(bucketedChanges.get(pair.pairIndex) ?? []),
+      ...fixedChanges,
+    ];
+    for (const change of textChanges) {
+      if (change.category === 'text') {
+        change.category = classifyChangeCategory(change, pageHeight);
+      }
+    }
+
+    const allChanges = [...textChanges];
+    allChanges.push(
+      ...diffAnnotations(
+        left.annotations ?? [],
+        right.annotations ?? [],
+        allChanges.length
+      )
+    );
+    allChanges.push(
+      ...diffImages(left.images ?? [], right.images ?? [], allChanges.length)
+    );
+
+    results.set(pair.pairIndex, {
+      status: allChanges.length > 0 ? 'changed' : 'match',
+      leftPageNumber: left.pageNumber,
+      rightPageNumber: right.pageNumber,
+      changes: allChanges,
+      summary: summarizeChanges(textChanges),
+      categorySummary: buildCategorySummary(allChanges),
+      visualDiff: null,
+      confidence: pair.confidence,
+      usedOcr: left.source === 'ocr' || right.source === 'ocr',
+    });
+  }
+
+  return results;
+}

--- a/src/js/compare/engine/diff-text-runs.ts
+++ b/src/js/compare/engine/diff-text-runs.ts
@@ -21,6 +21,7 @@ interface WordToken {
   rect: CompareRectangle;
   fontName?: string;
   fontSize?: number;
+  pageNumber?: number;
 }
 
 function getCharMap(line: CompareTextItem): CharPosition[] {
@@ -42,6 +43,7 @@ function splitLineIntoWords(line: CompareTextItem): WordToken[] {
       rect: token.rect,
       fontName: token.fontName,
       fontSize: token.fontSize,
+      pageNumber: line.pageNumber,
     }));
     if (!containsCJK(line.normalizedText)) return baseTokens;
     return baseTokens.flatMap(splitCJKToken);
@@ -73,6 +75,7 @@ function splitLineIntoWords(line: CompareTextItem): WordToken[] {
           width: word.length * charWidth,
           height: line.rect.height,
         },
+        pageNumber: line.pageNumber,
       };
     }
 
@@ -83,6 +86,7 @@ function splitLineIntoWords(line: CompareTextItem): WordToken[] {
       word,
       compareWord: word.toLowerCase(),
       rect: { x, y: line.rect.y, width: w, height: line.rect.height },
+      pageNumber: line.pageNumber,
     };
   });
 
@@ -108,6 +112,7 @@ function splitCJKToken(token: WordToken): WordToken[] {
       word: seg,
       compareWord: seg.toLowerCase(),
       rect: { x, y: token.rect.y, width, height: token.rect.height },
+      pageNumber: token.pageNumber,
     };
   });
 }
@@ -168,6 +173,8 @@ function createWordChange(
   const id = `${type}-${changes.length}`;
   const beforeRects = groupAdjacentRects(beforeWords.map((w) => w.rect));
   const afterRects = groupAdjacentRects(afterWords.map((w) => w.rect));
+  const beforePage = beforeWords[0]?.pageNumber;
+  const afterPage = afterWords[0]?.pageNumber;
 
   if (type === 'modified') {
     changes.push({
@@ -179,6 +186,8 @@ function createWordChange(
       afterText,
       beforeRects,
       afterRects,
+      beforePage,
+      afterPage,
     });
   } else if (type === 'removed') {
     changes.push({
@@ -190,6 +199,7 @@ function createWordChange(
       afterText: '',
       beforeRects,
       afterRects: [],
+      beforePage,
     });
   } else {
     changes.push({
@@ -201,6 +211,7 @@ function createWordChange(
       afterText,
       beforeRects: [],
       afterRects,
+      afterPage,
     });
   }
 }
@@ -313,6 +324,8 @@ function detectStyleChanges(
     text: string;
     beforeRects: CompareRectangle[];
     afterRects: CompareRectangle[];
+    beforePage: number | undefined;
+    afterPage: number | undefined;
   }
 
   const fragments: StyleFragment[] = [];
@@ -357,6 +370,8 @@ function detectStyleChanges(
           text: bTokens.map((w) => w.word).join(' '),
           beforeRects: groupAdjacentRects(bTokens.map((w) => w.rect)),
           afterRects: groupAdjacentRects(aTokens.map((w) => w.rect)),
+          beforePage: bTokens[0].pageNumber,
+          afterPage: aTokens[0].pageNumber,
         });
         styleRunStart = -1;
       }
@@ -399,6 +414,8 @@ function detectStyleChanges(
       afterText: allText,
       beforeRects: allBeforeRects,
       afterRects: allAfterRects,
+      beforePage: groupFrags[0].beforePage,
+      afterPage: groupFrags[0].afterPage,
     });
   }
 }
@@ -462,6 +479,8 @@ function detectMovedText(changes: CompareTextChange[]) {
         afterText: bestMatch.afterText,
         beforeRects: rem.beforeRects,
         afterRects: bestMatch.afterRects,
+        beforePage: rem.beforePage,
+        afterPage: bestMatch.afterPage,
       });
     }
   }

--- a/src/js/compare/engine/extract-page-model.ts
+++ b/src/js/compare/engine/extract-page-model.ts
@@ -14,6 +14,11 @@ import {
   containsCJK,
   segmentCJKText,
 } from './text-normalization.ts';
+import {
+  classifyItemLayers,
+  lineAngleDeg,
+  type ItemLayerSignal,
+} from './fixed-layer.ts';
 
 type PageTextItem = {
   str: string;
@@ -628,7 +633,7 @@ export async function extractPageModel(
   viewport: pdfjsLib.PageViewport
 ): Promise<ComparePageModel> {
   const [textContent, rawAnnotations, opList] = await Promise.all([
-    page.getTextContent(),
+    page.getTextContent({ includeMarkedContent: true }),
     page
       .getAnnotations({ intent: 'any' })
       .catch(() => [] as Array<Record<string, unknown>>),
@@ -658,13 +663,56 @@ export async function extractPageModel(
     }
   }
 
-  const rawItems = sortCompareTextItems(
-    textContent.items
-      .filter((item): item is PageTextItem => 'str' in item)
-      .map((item, index) => toRect(viewport, item, index, styles, fontNameMap))
-      .filter((item) => item.normalizedText.length > 0)
-  );
-  const textItems = mergeIntoLines(rawItems);
+  const classified: Array<{ item: CompareTextItem; signal: ItemLayerSignal }> =
+    [];
+  const artifactStack: boolean[] = [];
+  let textIndex = 0;
+
+  for (const raw of textContent.items) {
+    if ('type' in raw) {
+      const marked = raw as { type: string; tag?: string };
+      if (marked.type === 'endMarkedContent') {
+        artifactStack.pop();
+      } else {
+        artifactStack.push(marked.tag === 'Artifact');
+      }
+      continue;
+    }
+    if (!('str' in raw)) continue;
+
+    const pageItem = raw as PageTextItem;
+    const item = toRect(viewport, pageItem, textIndex++, styles, fontNameMap);
+    if (item.normalizedText.length === 0) continue;
+
+    const composite = pdfjsLib.Util.transform(
+      viewport.transform,
+      pageItem.transform
+    );
+    classified.push({
+      item,
+      signal: {
+        scale: Math.hypot(pageItem.transform[0], pageItem.transform[1]),
+        angleDeg: lineAngleDeg(Math.atan2(composite[1], composite[0])),
+        insideArtifact: artifactStack.some(Boolean),
+      },
+    });
+  }
+
+  const layers = classifyItemLayers(classified.map((entry) => entry.signal));
+  const bodyItems: CompareTextItem[] = [];
+  const backgroundItems: CompareTextItem[] = [];
+  classified.forEach((entry, index) => {
+    if (layers[index] === 'background') {
+      backgroundItems.push({ ...entry.item, layer: 'background' });
+    } else {
+      bodyItems.push(entry.item);
+    }
+  });
+
+  const textItems = [
+    ...mergeIntoLines(sortCompareTextItems(bodyItems)),
+    ...backgroundItems,
+  ];
 
   return {
     pageNumber: page.pageNumber,

--- a/src/js/compare/engine/fixed-layer.ts
+++ b/src/js/compare/engine/fixed-layer.ts
@@ -23,6 +23,33 @@ function median(values: number[]): number {
     : (sorted[mid - 1] + sorted[mid]) / 2;
 }
 
+function circularMeanAngleDeg(values: number[]): number {
+  if (values.length === 0) return 0;
+  let sumX = 0;
+  let sumY = 0;
+  for (const deg of values) {
+    const rad = (deg * 2 * Math.PI) / 180;
+    sumX += Math.cos(rad);
+    sumY += Math.sin(rad);
+  }
+  return lineAngleDeg(Math.atan2(sumY, sumX) / 2);
+}
+
+function signedAngleDeltaDeg(angle: number, reference: number): number {
+  const delta = (((angle - reference) % 180) + 180) % 180;
+  return delta > 90 ? delta - 180 : delta;
+}
+
+function dominantAngleDeg(values: number[]): number {
+  if (values.length === 0) return 0;
+  const center = circularMeanAngleDeg(values);
+  const unwrapped = values.map(
+    (value) => center + signedAngleDeltaDeg(value, center)
+  );
+  const dominant = median(unwrapped) % 180;
+  return dominant < 0 ? dominant + 180 : dominant;
+}
+
 export interface ItemLayerSignal {
   scale: number;
   angleDeg: number;
@@ -42,7 +69,7 @@ export function classifyItemLayers(
     (s) => s.angleDeg
   );
   const medianScale = median(scalePool);
-  const dominantAngle = median(anglePool);
+  const dominantAngle = dominantAngleDeg(anglePool);
 
   return signals.map((s) => {
     if (s.insideArtifact) return 'background';

--- a/src/js/compare/engine/fixed-layer.ts
+++ b/src/js/compare/engine/fixed-layer.ts
@@ -1,0 +1,104 @@
+import type { CompareTextItem } from '../types.ts';
+import { COMPARE_FURNITURE } from '../config.ts';
+
+const RAD_TO_DEG = 180 / Math.PI;
+
+export function lineAngleDeg(radians: number): number {
+  let deg = (radians * RAD_TO_DEG) % 180;
+  if (deg < 0) deg += 180;
+  return deg;
+}
+
+export function angularDistanceDeg(a: number, b: number): number {
+  const diff = Math.abs(a - b) % 180;
+  return Math.min(diff, 180 - diff);
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1
+    ? sorted[mid]
+    : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+export interface ItemLayerSignal {
+  scale: number;
+  angleDeg: number;
+  insideArtifact: boolean;
+}
+
+export function classifyItemLayers(
+  signals: ItemLayerSignal[]
+): Array<'body' | 'background'> {
+  if (signals.length === 0) return [];
+
+  const bodySignals = signals.filter((s) => !s.insideArtifact);
+  const scalePool = (bodySignals.length ? bodySignals : signals).map(
+    (s) => s.scale
+  );
+  const anglePool = (bodySignals.length ? bodySignals : signals).map(
+    (s) => s.angleDeg
+  );
+  const medianScale = median(scalePool);
+  const dominantAngle = median(anglePool);
+
+  return signals.map((s) => {
+    if (s.insideArtifact) return 'background';
+    if (
+      medianScale > 0 &&
+      s.scale > medianScale * COMPARE_FURNITURE.FONT_SCALE_OUTLIER
+    ) {
+      return 'background';
+    }
+    if (
+      angularDistanceDeg(s.angleDeg, dominantAngle) >
+      COMPARE_FURNITURE.ROTATION_TOLERANCE_DEG
+    ) {
+      return 'background';
+    }
+    return 'body';
+  });
+}
+
+export function itemPositionKey(
+  item: CompareTextItem,
+  quantize: number = COMPARE_FURNITURE.POSITION_QUANTIZE
+): string {
+  const qx = Math.round(item.rect.x / quantize);
+  const qy = Math.round(item.rect.y / quantize);
+  return `${qx}:${qy}:${item.normalizedText}`;
+}
+
+export function repeatedItemKeys(
+  pages: Array<{ textItems: CompareTextItem[] }>
+): Set<string> {
+  const pageCount = pages.length;
+  const threshold = Math.max(
+    COMPARE_FURNITURE.REPEAT_MIN_PAGES,
+    Math.ceil(pageCount * COMPARE_FURNITURE.REPEAT_PAGE_FRACTION)
+  );
+
+  const keyPages = new Map<string, Set<number>>();
+  pages.forEach((page, pageIndex) => {
+    const seen = new Set<string>();
+    for (const item of page.textItems) {
+      const key = itemPositionKey(item);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      let set = keyPages.get(key);
+      if (!set) {
+        set = new Set();
+        keyPages.set(key, set);
+      }
+      set.add(pageIndex);
+    }
+  });
+
+  const repeated = new Set<string>();
+  for (const [key, set] of keyPages) {
+    if (set.size >= threshold) repeated.add(key);
+  }
+  return repeated;
+}

--- a/src/js/compare/reporting/export-compare-pdf.ts
+++ b/src/js/compare/reporting/export-compare-pdf.ts
@@ -3,6 +3,7 @@ import * as pdfjsLib from 'pdfjs-dist';
 import type {
   CompareCaches,
   ComparePagePair,
+  ComparePageResult,
   CompareTextChange,
   ComparePdfExportMode,
 } from '../types.ts';
@@ -96,6 +97,7 @@ export async function exportComparePdf(
     useOcr?: boolean;
     ocrLanguage?: string;
     showOverlayDocument?: boolean;
+    documentResults?: Map<number, ComparePageResult>;
   }
 ) {
   if (!pdfDoc1 && !pdfDoc2) {
@@ -152,13 +154,15 @@ export async function exportComparePdf(
         ? await pdfDoc2.getPage(pair.rightPageNumber)
         : null;
 
-    const comparison = await computeComparisonForPair(
-      pdfDoc1,
-      pdfDoc2,
-      pair,
-      exportCaches,
-      renderContext
-    );
+    const comparison =
+      options?.documentResults?.get(pair.pairIndex) ??
+      (await computeComparisonForPair(
+        pdfDoc1,
+        pdfDoc2,
+        pair,
+        exportCaches,
+        renderContext
+      ));
     const changes = comparison.changes.filter(includeChange);
 
     if (mode === 'overlay') {

--- a/src/js/compare/types.ts
+++ b/src/js/compare/types.ts
@@ -3,6 +3,8 @@ import type { LRUCache } from './lru-cache.ts';
 
 export type CompareViewMode = 'overlay' | 'side-by-side';
 
+export type CompareComparisonMode = 'page' | 'document';
+
 export type ComparePdfExportMode =
   | 'split'
   | 'alternating'
@@ -79,6 +81,8 @@ export interface CompareTextItem {
   fragments?: CompareTextItem[];
   charMap?: CharPosition[];
   wordTokens?: CompareWordToken[];
+  pageNumber?: number;
+  layer?: 'body' | 'background';
 }
 
 export interface ComparePageModel {
@@ -155,6 +159,8 @@ export interface CompareTextChange {
   afterText: string;
   beforeRects: CompareRectangle[];
   afterRects: CompareRectangle[];
+  beforePage?: number;
+  afterPage?: number;
 }
 
 export interface CompareChangeSummary {
@@ -208,6 +214,8 @@ export interface CompareState {
   pdfDoc2: pdfjsLib.PDFDocumentProxy | null;
   currentPage: number;
   viewMode: CompareViewMode;
+  comparisonMode: CompareComparisonMode;
+  ignoreFixedContent: boolean;
   overlayChangeScope: CompareOverlayChangeScope;
   overlayDocumentVisible: boolean;
   isSyncScroll: boolean;

--- a/src/js/logic/compare-pdfs-page.ts
+++ b/src/js/logic/compare-pdfs-page.ts
@@ -10,19 +10,28 @@ import type {
   CompareCategoryFilterState,
 } from '../compare/types.ts';
 import { extractDocumentSignatures } from '../compare/engine/page-signatures.ts';
-import { pairPagesAsync } from '../compare/worker-api.ts';
+import { pairPagesAsync, diffTextRunsAsync } from '../compare/worker-api.ts';
 import type {
   ComparePdfExportMode,
+  CompareComparisonMode,
   CompareCaches,
   CompareRenderContext,
 } from '../compare/types.ts';
 import { exportComparePdf } from '../compare/reporting/export-compare-pdf.ts';
+import {
+  collectDocumentItems,
+  buildDocumentResults,
+  type DocumentPagePair,
+} from '../compare/engine/compare-document.ts';
 import { LRUCache } from '../compare/lru-cache.ts';
-import { COMPARE_CACHE_MAX_SIZE } from '../compare/config.ts';
+import { COMPARE_CACHE_MAX_SIZE, COMPARE_RENDER } from '../compare/config.ts';
 import {
   getElement,
   computeComparisonForPair,
   getComparisonCacheKey,
+  loadComparisonPage,
+  rescaleRect,
+  getRenderScale,
 } from './compare-render.ts';
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
@@ -35,6 +44,8 @@ const pageState: CompareState = {
   pdfDoc2: null,
   currentPage: 1,
   viewMode: 'side-by-side',
+  comparisonMode: 'page',
+  ignoreFixedContent: true,
   overlayChangeScope: 'all',
   overlayDocumentVisible: true,
   isSyncScroll: true,
@@ -67,6 +78,7 @@ const documentNames = {
   right: 'second.pdf',
 };
 
+let documentComparison: Map<number, ComparePageResult> | null = null;
 let renderGeneration = 0;
 
 function getActivePair() {
@@ -553,6 +565,126 @@ async function buildReportResults() {
   return results;
 }
 
+async function loadDocumentPageModels(
+  ctx: CompareRenderContext
+): Promise<DocumentPagePair[]> {
+  const pages: DocumentPagePair[] = [];
+  const total = pageState.pagePairs.length;
+
+  for (let i = 0; i < total; i += 1) {
+    const pair = pageState.pagePairs[i];
+    showLoader(
+      `Analyzing document ${i + 1} of ${total}...`,
+      ((i + 1) / Math.max(total, 1)) * 100
+    );
+    const left = await loadComparisonPage(
+      pageState.pdfDoc1,
+      pair.leftPageNumber,
+      'left',
+      undefined,
+      caches,
+      ctx
+    );
+    const right = await loadComparisonPage(
+      pageState.pdfDoc2,
+      pair.rightPageNumber,
+      'right',
+      undefined,
+      caches,
+      ctx
+    );
+    pages.push({ pair, left: left.model, right: right.model });
+  }
+
+  return pages;
+}
+
+async function ensureDocumentComparison(
+  ctx: CompareRenderContext
+): Promise<Map<number, ComparePageResult>> {
+  if (documentComparison) return documentComparison;
+
+  const pages = await loadDocumentPageModels(ctx);
+  const detectFixed = pageState.ignoreFixedContent;
+  const { beforeItems, afterItems } = collectDocumentItems(pages, detectFixed);
+  const diff = await diffTextRunsAsync(beforeItems, afterItems);
+  documentComparison = buildDocumentResults(pages, diff, detectFixed);
+  return documentComparison;
+}
+
+async function documentDisplayRatio(
+  pdfDoc: pdfjsLib.PDFDocumentProxy | null,
+  pageNumber: number | null,
+  container: HTMLElement,
+  ctx: CompareRenderContext
+): Promise<number> {
+  if (!pdfDoc || !pageNumber) return 1;
+  const page = await pdfDoc.getPage(pageNumber);
+  const displayScale = getRenderScale(
+    page,
+    container,
+    ctx.viewMode,
+    ctx.zoomLevel
+  );
+  return displayScale / COMPARE_RENDER.OFFLINE_SCALE;
+}
+
+async function buildDocumentPairComparison(
+  pair: ReturnType<typeof getActivePair>,
+  results: Map<number, ComparePageResult>,
+  ctx: CompareRenderContext,
+  container1: HTMLElement,
+  container2: HTMLElement
+): Promise<ComparePageResult> {
+  const base = results.get(pair!.pairIndex);
+  if (!base) {
+    return {
+      status: 'match',
+      leftPageNumber: pair!.leftPageNumber,
+      rightPageNumber: pair!.rightPageNumber,
+      changes: [],
+      summary: { added: 0, removed: 0, modified: 0, moved: 0, styleChanged: 0 },
+      categorySummary: {
+        text: 0,
+        image: 0,
+        'header-footer': 0,
+        annotation: 0,
+        formatting: 0,
+        background: 0,
+      },
+      visualDiff: null,
+      confidence: pair!.confidence,
+      usedOcr: false,
+    };
+  }
+
+  const ratioLeft = await documentDisplayRatio(
+    pageState.pdfDoc1,
+    pair!.leftPageNumber,
+    container1,
+    ctx
+  );
+  const ratioRight = await documentDisplayRatio(
+    pageState.pdfDoc2,
+    pair!.rightPageNumber,
+    container2,
+    ctx
+  );
+
+  return {
+    ...base,
+    changes: base.changes.map((change) => ({
+      ...change,
+      beforeRects: change.beforeRects.map((rect) =>
+        rescaleRect(rect, ratioLeft, ratioLeft)
+      ),
+      afterRects: change.afterRects.map((rect) =>
+        rescaleRect(rect, ratioRight, ratioRight)
+      ),
+    })),
+  };
+}
+
 async function renderBothPages() {
   if (!pageState.pdfDoc1 || !pageState.pdfDoc2) return;
 
@@ -579,27 +711,68 @@ async function renderBothPages() {
 
   const ctx = getRenderContext();
 
-  const comparison = await computeComparisonForPair(
-    pageState.pdfDoc1,
-    pageState.pdfDoc2,
-    pair,
-    caches,
-    ctx,
-    {
-      renderTargets: {
-        left: {
-          canvas: canvas1,
-          container: container1,
-          placeholderId: 'placeholder-1',
-        },
-        right: {
-          canvas: canvas2,
-          container: container2,
-          placeholderId: 'placeholder-2',
-        },
+  let comparison: ComparePageResult;
+
+  if (pageState.comparisonMode === 'document') {
+    const results = await ensureDocumentComparison(ctx);
+    if (gen !== renderGeneration) return;
+
+    await loadComparisonPage(
+      pageState.pdfDoc1,
+      pair.leftPageNumber,
+      'left',
+      {
+        canvas: canvas1,
+        container: container1,
+        placeholderId: 'placeholder-1',
       },
-    }
-  );
+      caches,
+      ctx
+    );
+    await loadComparisonPage(
+      pageState.pdfDoc2,
+      pair.rightPageNumber,
+      'right',
+      {
+        canvas: canvas2,
+        container: container2,
+        placeholderId: 'placeholder-2',
+      },
+      caches,
+      ctx
+    );
+    if (gen !== renderGeneration) return;
+
+    comparison = await buildDocumentPairComparison(
+      pair,
+      results,
+      ctx,
+      container1,
+      container2
+    );
+  } else {
+    comparison = await computeComparisonForPair(
+      pageState.pdfDoc1,
+      pageState.pdfDoc2,
+      pair,
+      caches,
+      ctx,
+      {
+        renderTargets: {
+          left: {
+            canvas: canvas1,
+            container: container1,
+            placeholderId: 'placeholder-1',
+          },
+          right: {
+            canvas: canvas2,
+            container: container2,
+            placeholderId: 'placeholder-2',
+          },
+        },
+      }
+    );
+  }
 
   if (gen !== renderGeneration) return;
 
@@ -704,6 +877,27 @@ function setViewMode(mode: 'overlay' | 'side-by-side') {
   }
 }
 
+function setComparisonMode(mode: CompareComparisonMode) {
+  if (pageState.comparisonMode === mode) return;
+  pageState.comparisonMode = mode;
+
+  const btnPage = getElement<HTMLButtonElement>('compare-mode-page');
+  const btnDocument = getElement<HTMLButtonElement>('compare-mode-document');
+  const applyState = (button: HTMLButtonElement | null, active: boolean) => {
+    if (!button) return;
+    button.classList.toggle('bg-indigo-600', active);
+    button.classList.toggle('bg-gray-700', !active);
+  };
+  applyState(btnPage, mode === 'page');
+  applyState(btnDocument, mode === 'document');
+
+  pageState.activeChangeIndex = 0;
+
+  if (pageState.pdfDoc1 && pageState.pdfDoc2) {
+    renderBothPages().catch(console.error);
+  }
+}
+
 async function handleFileInput(
   inputId: string,
   docKey: 'pdfDoc1' | 'pdfDoc2',
@@ -753,6 +947,7 @@ async function handleFileInput(
       caches.pageModelCache.clear();
       caches.comparisonCache.clear();
       caches.comparisonResultsCache.clear();
+      documentComparison = null;
       pageState.changeSearchQuery = '';
 
       const searchInput = getElement<HTMLInputElement>('compare-search-input');
@@ -850,6 +1045,23 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   }
 
+  const btnModePage = getElement<HTMLButtonElement>('compare-mode-page');
+  const btnModeDocument = getElement<HTMLButtonElement>(
+    'compare-mode-document'
+  );
+
+  if (btnModePage) {
+    btnModePage.addEventListener('click', function () {
+      setComparisonMode('page');
+    });
+  }
+
+  if (btnModeDocument) {
+    btnModeDocument.addEventListener('click', function () {
+      setComparisonMode('document');
+    });
+  }
+
   const flickerBtn = getElement<HTMLButtonElement>('flicker-btn');
   const canvas2 = getElement<HTMLCanvasElement>(
     'canvas-compare-2'
@@ -885,6 +1097,7 @@ document.addEventListener('DOMContentLoaded', function () {
   const exportDropdownMenu = getElement<HTMLDivElement>('export-dropdown-menu');
   const ocrToggle = getElement<HTMLInputElement>('ocr-toggle');
   const overlayOcrToggle = getElement<HTMLInputElement>('overlay-ocr-toggle');
+  const ignoreFixedToggle = getElement<HTMLInputElement>('ignore-fixed-toggle');
   const searchInput = getElement<HTMLInputElement>('compare-search-input');
   const overlayAllBtn = getElement<HTMLButtonElement>('overlay-scope-all');
   const overlayContentOnlyBtn = getElement<HTMLButtonElement>(
@@ -1088,6 +1301,7 @@ document.addEventListener('DOMContentLoaded', function () {
       caches.pageModelCache.clear();
       caches.comparisonCache.clear();
       caches.comparisonResultsCache.clear();
+      documentComparison = null;
       if (pageState.pdfDoc1 && pageState.pdfDoc2) {
         await renderBothPages();
       }
@@ -1108,6 +1322,21 @@ document.addEventListener('DOMContentLoaded', function () {
     overlayOcrToggle.checked = pageState.useOcr;
     overlayOcrToggle.addEventListener('change', async function () {
       await handleOcrToggleChange(overlayOcrToggle.checked);
+    });
+  }
+
+  if (ignoreFixedToggle) {
+    ignoreFixedToggle.checked = pageState.ignoreFixedContent;
+    ignoreFixedToggle.addEventListener('change', function () {
+      pageState.ignoreFixedContent = ignoreFixedToggle.checked;
+      documentComparison = null;
+      if (
+        pageState.comparisonMode === 'document' &&
+        pageState.pdfDoc1 &&
+        pageState.pdfDoc2
+      ) {
+        renderBothPages().catch(console.error);
+      }
     });
   }
 
@@ -1163,6 +1392,10 @@ document.addEventListener('DOMContentLoaded', function () {
         exportDropdownMenu.classList.add('hidden');
         try {
           showLoader('Preparing PDF export...');
+          const documentResults =
+            pageState.comparisonMode === 'document'
+              ? await ensureDocumentComparison(getRenderContext())
+              : undefined;
           await exportComparePdf(
             mode,
             pageState.pdfDoc1,
@@ -1172,6 +1405,7 @@ document.addEventListener('DOMContentLoaded', function () {
               showLoader(message, percent);
             },
             {
+              documentResults,
               useOcr: pageState.useOcr,
               ocrLanguage: pageState.ocrLanguage,
               showOverlayDocument:

--- a/src/js/logic/compare-pdfs-page.ts
+++ b/src/js/logic/compare-pdfs-page.ts
@@ -79,7 +79,18 @@ const documentNames = {
 };
 
 let documentComparison: Map<number, ComparePageResult> | null = null;
+let documentComparisonEpoch = 0;
+let documentComparisonPending: {
+  epoch: number;
+  promise: Promise<Map<number, ComparePageResult>>;
+} | null = null;
 let renderGeneration = 0;
+
+function invalidateDocumentComparison() {
+  documentComparison = null;
+  documentComparisonPending = null;
+  documentComparisonEpoch += 1;
+}
 
 function getActivePair() {
   return pageState.pagePairs[pageState.currentPage - 1] || null;
@@ -603,13 +614,28 @@ async function ensureDocumentComparison(
   ctx: CompareRenderContext
 ): Promise<Map<number, ComparePageResult>> {
   if (documentComparison) return documentComparison;
+  if (documentComparisonPending?.epoch === documentComparisonEpoch) {
+    return documentComparisonPending.promise;
+  }
 
-  const pages = await loadDocumentPageModels(ctx);
-  const detectFixed = pageState.ignoreFixedContent;
-  const { beforeItems, afterItems } = collectDocumentItems(pages, detectFixed);
-  const diff = await diffTextRunsAsync(beforeItems, afterItems);
-  documentComparison = buildDocumentResults(pages, diff, detectFixed);
-  return documentComparison;
+  const epoch = documentComparisonEpoch;
+  const run = (async () => {
+    const pages = await loadDocumentPageModels(ctx);
+    const detectFixed = pageState.ignoreFixedContent;
+    const { beforeItems, afterItems } = collectDocumentItems(
+      pages,
+      detectFixed
+    );
+    const diff = await diffTextRunsAsync(beforeItems, afterItems);
+    const results = buildDocumentResults(pages, diff, detectFixed);
+    if (epoch === documentComparisonEpoch) {
+      documentComparison = results;
+    }
+    return results;
+  })();
+
+  documentComparisonPending = { epoch, promise: run };
+  return run;
 }
 
 async function documentDisplayRatio(
@@ -947,7 +973,7 @@ async function handleFileInput(
       caches.pageModelCache.clear();
       caches.comparisonCache.clear();
       caches.comparisonResultsCache.clear();
-      documentComparison = null;
+      invalidateDocumentComparison();
       pageState.changeSearchQuery = '';
 
       const searchInput = getElement<HTMLInputElement>('compare-search-input');
@@ -1301,7 +1327,7 @@ document.addEventListener('DOMContentLoaded', function () {
       caches.pageModelCache.clear();
       caches.comparisonCache.clear();
       caches.comparisonResultsCache.clear();
-      documentComparison = null;
+      invalidateDocumentComparison();
       if (pageState.pdfDoc1 && pageState.pdfDoc2) {
         await renderBothPages();
       }
@@ -1329,7 +1355,7 @@ document.addEventListener('DOMContentLoaded', function () {
     ignoreFixedToggle.checked = pageState.ignoreFixedContent;
     ignoreFixedToggle.addEventListener('change', function () {
       pageState.ignoreFixedContent = ignoreFixedToggle.checked;
-      documentComparison = null;
+      invalidateDocumentComparison();
       if (
         pageState.comparisonMode === 'document' &&
         pageState.pdfDoc1 &&

--- a/src/js/logic/compare-pdfs-page.ts
+++ b/src/js/logic/compare-pdfs-page.ts
@@ -635,6 +635,12 @@ async function ensureDocumentComparison(
   })();
 
   documentComparisonPending = { epoch, promise: run };
+  const clearPending = () => {
+    if (documentComparisonPending?.promise === run) {
+      documentComparisonPending = null;
+    }
+  };
+  void run.then(clearPending, clearPending);
   return run;
 }
 

--- a/src/js/logic/compare-render.ts
+++ b/src/js/logic/compare-render.ts
@@ -81,7 +81,7 @@ function shouldUseOcrForModel(model: ComparePageModel) {
   return !model.hasText || isLowQualityExtractedText(model.plainText);
 }
 
-function rescaleRect(
+export function rescaleRect(
   rect: CompareRectangle,
   scaleX: number,
   scaleY: number

--- a/src/pages/compare-pdfs.html
+++ b/src/pages/compare-pdfs.html
@@ -697,6 +697,38 @@
 
             <div class="border-l border-gray-700 h-5 mx-1"></div>
 
+            <div class="bg-gray-700 p-0.5 rounded flex gap-0.5">
+              <button
+                id="compare-mode-page"
+                class="btn bg-indigo-600 px-2.5 py-1 rounded text-xs font-semibold"
+                title="Compare each page against its aligned counterpart"
+              >
+                Per-page
+              </button>
+              <button
+                id="compare-mode-document"
+                class="btn bg-gray-700 px-2.5 py-1 rounded text-xs font-semibold"
+                title="Compare the documents as a whole so reflowed content is not flagged"
+              >
+                Whole document
+              </button>
+            </div>
+
+            <label
+              class="flex items-center gap-1.5 text-xs text-gray-300 cursor-pointer"
+              title="Exclude headers, footers, page numbers and watermarks from the whole-document comparison"
+            >
+              <input
+                type="checkbox"
+                id="ignore-fixed-toggle"
+                checked
+                class="w-3.5 h-3.5 rounded text-indigo-600 bg-gray-700 border-gray-600"
+              />
+              Ignore headers &amp; watermarks
+            </label>
+
+            <div class="border-l border-gray-700 h-5 mx-1"></div>
+
             <button
               id="prev-change-btn"
               class="btn bg-gray-700 hover:bg-gray-600 px-2.5 py-1 rounded text-xs font-semibold disabled:opacity-50"

--- a/src/tests/compare/compare-document.test.ts
+++ b/src/tests/compare/compare-document.test.ts
@@ -1,0 +1,322 @@
+import { describe, expect, it } from 'vitest';
+
+import { diffTextRuns } from '@/js/compare/engine/diff-text-runs.ts';
+import {
+  collectDocumentItems,
+  buildDocumentResults,
+  type DocumentPagePair,
+} from '@/js/compare/engine/compare-document.ts';
+import type {
+  ComparePagePair,
+  ComparePageModel,
+  CompareTextItem,
+} from '@/js/compare/types.ts';
+
+function makeItem(id: string, text: string): CompareTextItem {
+  return {
+    id,
+    text,
+    normalizedText: text,
+    rect: { x: 0, y: 50, width: 10, height: 10 },
+  };
+}
+
+function makePage(pageNumber: number, words: string[]): ComparePageModel {
+  const textItems = words.map((word, index) =>
+    makeItem(`${pageNumber}-${index}`, word)
+  );
+  return {
+    pageNumber,
+    width: 100,
+    height: 100,
+    textItems,
+    plainText: words.join(' '),
+    hasText: words.length > 0,
+    source: 'pdfjs',
+  };
+}
+
+function makePair(
+  pairIndex: number,
+  leftPageNumber: number | null,
+  rightPageNumber: number | null
+): ComparePagePair {
+  return { pairIndex, leftPageNumber, rightPageNumber, confidence: 1 };
+}
+
+function diffDocument(pages: DocumentPagePair[]) {
+  const { beforeItems, afterItems } = collectDocumentItems(pages);
+  return buildDocumentResults(pages, diffTextRuns(beforeItems, afterItems));
+}
+
+describe('buildDocumentResults', () => {
+  it('does not flag content that merely reflows onto later pages', () => {
+    const pages: DocumentPagePair[] = [
+      {
+        pair: makePair(0, 1, 1),
+        left: makePage(1, ['alpha', 'bravo', 'charlie']),
+        right: makePage(1, ['xray', 'alpha', 'bravo']),
+      },
+      {
+        pair: makePair(1, 2, 2),
+        left: makePage(2, ['delta', 'echo', 'foxtrot']),
+        right: makePage(2, ['charlie', 'delta', 'echo']),
+      },
+      {
+        pair: makePair(2, 3, 3),
+        left: makePage(3, ['golf', 'hotel']),
+        right: makePage(3, ['foxtrot', 'golf', 'hotel']),
+      },
+    ];
+
+    const results = diffDocument(pages);
+
+    expect(results.get(0)!.summary.added).toBe(1);
+    expect(results.get(0)!.changes).toHaveLength(1);
+    expect(results.get(0)!.changes[0].type).toBe('added');
+    expect(results.get(0)!.changes[0].afterText).toBe('xray');
+
+    expect(results.get(1)!.status).toBe('match');
+    expect(results.get(1)!.changes).toHaveLength(0);
+    expect(results.get(2)!.status).toBe('match');
+    expect(results.get(2)!.changes).toHaveLength(0);
+  });
+
+  it('per-page diffing flags the same reflow as spurious changes', () => {
+    const before = makePage(2, ['delta', 'echo', 'foxtrot']);
+    const after = makePage(2, ['charlie', 'delta', 'echo']);
+
+    const perPage = diffTextRuns(before.textItems, after.textItems);
+
+    expect(perPage.changes.length).toBeGreaterThan(0);
+  });
+
+  it('attributes a change to the page its content lands on', () => {
+    const pages: DocumentPagePair[] = [
+      {
+        pair: makePair(0, 1, 1),
+        left: makePage(1, ['alpha', 'bravo']),
+        right: makePage(1, ['alpha', 'bravo']),
+      },
+      {
+        pair: makePair(1, 2, 2),
+        left: makePage(2, ['charlie', 'delta']),
+        right: makePage(2, ['charlie', 'inserted', 'delta']),
+      },
+    ];
+
+    const results = diffDocument(pages);
+
+    expect(results.get(0)!.status).toBe('match');
+    expect(results.get(1)!.summary.added).toBe(1);
+    expect(results.get(1)!.changes[0].afterText).toBe('inserted');
+    expect(results.get(1)!.changes[0].afterPage).toBe(2);
+  });
+
+  it('splits a cross-page moved block onto both source and target pages', () => {
+    const anchorOne =
+      'aaa this is a long stable anchor line that stays put across both documents unchanged';
+    const anchorTwo =
+      'bbb another long stable anchor paragraph remaining in place unchanged across both documents entirely';
+    const movable = 'movable trio words extra';
+
+    const pages: DocumentPagePair[] = [
+      {
+        pair: makePair(0, 1, 1),
+        left: makePage(1, [anchorOne, movable]),
+        right: makePage(1, [anchorOne]),
+      },
+      {
+        pair: makePair(1, 2, 2),
+        left: makePage(2, [anchorTwo]),
+        right: makePage(2, [anchorTwo, movable]),
+      },
+    ];
+
+    const results = diffDocument(pages);
+
+    const movedOnPage0 = results
+      .get(0)!
+      .changes.filter((c) => c.type === 'moved');
+    const movedOnPage1 = results
+      .get(1)!
+      .changes.filter((c) => c.type === 'moved');
+
+    expect(movedOnPage0).toHaveLength(1);
+    expect(movedOnPage1).toHaveLength(1);
+
+    const both = [...movedOnPage0, ...movedOnPage1];
+    const source = both.find((c) => c.id.endsWith('-b'));
+    const target = both.find((c) => c.id.endsWith('-a'));
+
+    expect(source!.afterRects).toHaveLength(0);
+    expect(target!.beforeRects).toHaveLength(0);
+  });
+
+  it('keeps the page-added marker for pages that exist only on one side', () => {
+    const pages: DocumentPagePair[] = [
+      {
+        pair: makePair(0, 1, 1),
+        left: makePage(1, ['alpha', 'bravo']),
+        right: makePage(1, ['alpha', 'bravo']),
+      },
+      {
+        pair: makePair(1, null, 2),
+        left: null,
+        right: makePage(2, ['brand', 'new', 'page']),
+      },
+    ];
+
+    const results = diffDocument(pages);
+
+    expect(results.get(1)!.status).toBe('right-only');
+    expect(results.get(1)!.changes[0].type).toBe('page-added');
+  });
+});
+
+describe('diffTextRuns page tagging', () => {
+  it('populates beforePage and afterPage from tagged items', () => {
+    const before: CompareTextItem[] = [
+      { ...makeItem('a', 'hello'), pageNumber: 3 },
+    ];
+    const after: CompareTextItem[] = [
+      { ...makeItem('a', 'hello'), pageNumber: 3 },
+      { ...makeItem('b', 'world'), pageNumber: 3 },
+    ];
+
+    const result = diffTextRuns(before, after);
+
+    expect(result.changes[0].type).toBe('added');
+    expect(result.changes[0].afterPage).toBe(3);
+  });
+
+  it('leaves page fields undefined when items are untagged', () => {
+    const result = diffTextRuns(
+      [makeItem('a', 'hello')],
+      [makeItem('a', 'hello'), makeItem('b', 'world')]
+    );
+
+    expect(result.changes[0].beforePage).toBeUndefined();
+    expect(result.changes[0].afterPage).toBeUndefined();
+  });
+});
+
+function placedItem(
+  id: string,
+  text: string,
+  x: number,
+  y: number,
+  layer?: 'background'
+): CompareTextItem {
+  return {
+    id,
+    text,
+    normalizedText: text,
+    rect: { x, y, width: text.length * 6, height: 8 },
+    layer,
+  };
+}
+
+function furniturePage(
+  pageNumber: number,
+  bodyText: string,
+  pageLabel: string
+): ComparePageModel {
+  return {
+    pageNumber,
+    width: 100,
+    height: 100,
+    textItems: [
+      placedItem(`wm-${pageNumber}`, 'CONCEPT', 30, 45, 'background'),
+      placedItem(`body-${pageNumber}`, bodyText, 40, 50),
+      placedItem(`pn-${pageNumber}`, pageLabel, 48, 95),
+    ],
+    plainText: bodyText,
+    hasText: true,
+    source: 'pdfjs',
+  };
+}
+
+describe('buildDocumentResults page-fixed content', () => {
+  it('keeps the watermark and footer out of the reflow stream', () => {
+    const pages: DocumentPagePair[] = [
+      {
+        pair: makePair(0, 1, 1),
+        left: furniturePage(1, 'shared body line', '3'),
+        right: furniturePage(1, 'shared body line', '3'),
+      },
+    ];
+
+    const { beforeItems } = collectDocumentItems(pages);
+    const streamText = beforeItems.map((item) => item.normalizedText);
+
+    expect(streamText).toContain('shared body line');
+    expect(streamText).not.toContain('CONCEPT');
+    expect(streamText).not.toContain('3');
+  });
+
+  it('includes furniture in the flow when detection is disabled', () => {
+    const pages: DocumentPagePair[] = [
+      {
+        pair: makePair(0, 1, 1),
+        left: furniturePage(1, 'shared body line', '3'),
+        right: furniturePage(1, 'shared body line', '3'),
+      },
+    ];
+
+    const streamText = collectDocumentItems(pages, false).beforeItems.map(
+      (item) => item.normalizedText
+    );
+
+    expect(streamText).toContain('CONCEPT');
+    expect(streamText).toContain('3');
+  });
+
+  it('reports no change when body and furniture are identical', () => {
+    const pages: DocumentPagePair[] = [
+      {
+        pair: makePair(0, 1, 1),
+        left: furniturePage(1, 'shared body line', '3'),
+        right: furniturePage(1, 'shared body line', '3'),
+      },
+    ];
+
+    const results = diffDocument(pages);
+
+    expect(results.get(0)!.status).toBe('match');
+    expect(results.get(0)!.changes).toHaveLength(0);
+  });
+
+  it('still surfaces a real body edit while furniture stays silent', () => {
+    const pages: DocumentPagePair[] = [
+      {
+        pair: makePair(0, 1, 1),
+        left: furniturePage(1, 'body before edit', '3'),
+        right: furniturePage(1, 'body after edit', '3'),
+      },
+    ];
+
+    const results = diffDocument(pages);
+    const changes = results.get(0)!.changes;
+
+    expect(changes.length).toBeGreaterThan(0);
+    expect(changes.every((c) => c.beforeText !== 'CONCEPT')).toBe(true);
+  });
+
+  it('surfaces a genuinely changed footer via the per-page fixed diff', () => {
+    const pages: DocumentPagePair[] = [
+      {
+        pair: makePair(0, 1, 1),
+        left: furniturePage(1, 'shared body line', '3'),
+        right: furniturePage(1, 'shared body line', '4'),
+      },
+    ];
+
+    const results = diffDocument(pages);
+    const changes = results.get(0)!.changes;
+
+    expect(
+      changes.some((c) => c.beforeText === '3' && c.afterText === '4')
+    ).toBe(true);
+  });
+});

--- a/src/tests/compare/fixed-layer.test.ts
+++ b/src/tests/compare/fixed-layer.test.ts
@@ -65,6 +65,19 @@ describe('classifyItemLayers', () => {
     expect(result[3]).toBe('background');
   });
 
+  it('keeps body glyphs whose angles straddle the 0/180 wrap boundary', () => {
+    const signals: ItemLayerSignal[] = [
+      { scale: 10, angleDeg: 0.5, insideArtifact: false },
+      { scale: 10, angleDeg: 179.5, insideArtifact: false },
+      { scale: 10, angleDeg: 0.3, insideArtifact: false },
+      { scale: 10, angleDeg: 179.8, insideArtifact: false },
+      { scale: 10, angleDeg: 90, insideArtifact: false },
+    ];
+    const result = classifyItemLayers(signals);
+    expect(result.slice(0, 4)).toEqual(['body', 'body', 'body', 'body']);
+    expect(result[4]).toBe('background');
+  });
+
   it('flags marked-content artifacts regardless of geometry', () => {
     const signals: ItemLayerSignal[] = [
       { scale: 10, angleDeg: 0, insideArtifact: false },

--- a/src/tests/compare/fixed-layer.test.ts
+++ b/src/tests/compare/fixed-layer.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  classifyItemLayers,
+  lineAngleDeg,
+  angularDistanceDeg,
+  itemPositionKey,
+  repeatedItemKeys,
+  type ItemLayerSignal,
+} from '@/js/compare/engine/fixed-layer.ts';
+import {
+  mergeIntoLines,
+  sortCompareTextItems,
+} from '@/js/compare/engine/extract-page-model.ts';
+import type { CompareTextItem } from '@/js/compare/types.ts';
+
+function bodyItem(
+  id: string,
+  text: string,
+  x: number,
+  y: number
+): CompareTextItem {
+  return {
+    id,
+    text,
+    normalizedText: text,
+    rect: { x, y, width: text.length * 6, height: 10 },
+  };
+}
+
+describe('classifyItemLayers', () => {
+  it('flags an oversized glyph as background', () => {
+    const signals: ItemLayerSignal[] = [
+      { scale: 10, angleDeg: 0, insideArtifact: false },
+      { scale: 10, angleDeg: 0, insideArtifact: false },
+      { scale: 10, angleDeg: 0, insideArtifact: false },
+      { scale: 40, angleDeg: 0, insideArtifact: false },
+    ];
+    expect(classifyItemLayers(signals)).toEqual([
+      'body',
+      'body',
+      'body',
+      'background',
+    ]);
+  });
+
+  it('flags an off-axis glyph relative to the page dominant orientation', () => {
+    const signals: ItemLayerSignal[] = [
+      { scale: 10, angleDeg: 0, insideArtifact: false },
+      { scale: 10, angleDeg: 0, insideArtifact: false },
+      { scale: 10, angleDeg: 45, insideArtifact: false },
+    ];
+    expect(classifyItemLayers(signals)).toEqual(['body', 'body', 'background']);
+  });
+
+  it('measures orientation relative to a rotated page, not absolute zero', () => {
+    const signals: ItemLayerSignal[] = [
+      { scale: 10, angleDeg: 90, insideArtifact: false },
+      { scale: 10, angleDeg: 90, insideArtifact: false },
+      { scale: 10, angleDeg: 90, insideArtifact: false },
+      { scale: 10, angleDeg: 45, insideArtifact: false },
+    ];
+    const result = classifyItemLayers(signals);
+    expect(result.slice(0, 3)).toEqual(['body', 'body', 'body']);
+    expect(result[3]).toBe('background');
+  });
+
+  it('flags marked-content artifacts regardless of geometry', () => {
+    const signals: ItemLayerSignal[] = [
+      { scale: 10, angleDeg: 0, insideArtifact: false },
+      { scale: 10, angleDeg: 0, insideArtifact: true },
+    ];
+    expect(classifyItemLayers(signals)).toEqual(['body', 'background']);
+  });
+
+  it('excludes artifacts from the body median so they cannot skew it', () => {
+    const signals: ItemLayerSignal[] = [
+      { scale: 10, angleDeg: 0, insideArtifact: false },
+      { scale: 10, angleDeg: 0, insideArtifact: false },
+      { scale: 60, angleDeg: 0, insideArtifact: true },
+      { scale: 30, angleDeg: 0, insideArtifact: false },
+    ];
+    expect(classifyItemLayers(signals)).toEqual([
+      'body',
+      'body',
+      'background',
+      'background',
+    ]);
+  });
+});
+
+describe('angle helpers', () => {
+  it('normalizes radians to a [0,180) line orientation', () => {
+    expect(lineAngleDeg(0)).toBeCloseTo(0);
+    expect(lineAngleDeg(Math.PI)).toBeCloseTo(0);
+    expect(lineAngleDeg(Math.PI / 4)).toBeCloseTo(45);
+  });
+
+  it('treats 170 and 10 degrees as 20 apart, not 160', () => {
+    expect(angularDistanceDeg(170, 10)).toBeCloseTo(20);
+  });
+});
+
+describe('body-only merge keeps watermark glyphs off body words', () => {
+  it('does not glue a background glyph onto an adjacent body word', () => {
+    const verpanden = bodyItem('a', 'verpanden', 0, 50);
+    const watermarkT: CompareTextItem = {
+      ...bodyItem('wm', 'T', 55, 48),
+      layer: 'background',
+    };
+
+    const body = [verpanden];
+    const merged = mergeIntoLines(sortCompareTextItems(body));
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].normalizedText).toBe('verpanden');
+
+    const textItems = [...merged, watermarkT];
+    expect(textItems.map((i) => i.normalizedText)).toEqual(['verpanden', 'T']);
+  });
+});
+
+describe('repeatedItemKeys', () => {
+  it('flags an element that recurs at the same position and text across pages', () => {
+    const watermark = (page: number) => ({
+      textItems: [
+        bodyItem(`w-${page}`, 'CONCEPT', 100, 200),
+        bodyItem(`b-${page}`, `unique body ${page}`, 40, 300),
+      ],
+    });
+    const pages = [watermark(1), watermark(2), watermark(3), watermark(4)];
+
+    const keys = repeatedItemKeys(pages);
+
+    expect(keys.has(itemPositionKey(bodyItem('x', 'CONCEPT', 100, 200)))).toBe(
+      true
+    );
+    expect(
+      keys.has(itemPositionKey(bodyItem('x', 'unique body 1', 40, 300)))
+    ).toBe(false);
+  });
+
+  it('does not flag body lines that merely share a y-grid across pages', () => {
+    const page = (n: number) => ({
+      textItems: [
+        bodyItem(`l-${n}`, `line ${n} alpha`, 40, 100),
+        bodyItem(`m-${n}`, `line ${n} beta`, 40, 120),
+      ],
+    });
+    const keys = repeatedItemKeys([page(1), page(2), page(3), page(4)]);
+    expect(keys.size).toBe(0);
+  });
+});


### PR DESCRIPTION
### Description

Adds an opt-in **"Whole document"** comparison mode to the Compare tool, alongside the existing per-page mode, and fixes two classes of false positive that show up on real multi-page documents.

**Motivation**

The Compare tool aligns pages and then diffs each aligned page **pair independently**. When an edit on an early page reflows content onto later pages, every downstream page is reported as heavily changed even though the document content is unchanged. Two further problems surfaced while testing on real documents:

- A diagonal/oversized **watermark** is extracted as individual glyphs that get merged into adjacent body words during line reconstruction (e.g. `verpanden` → `verpandenT`), producing spurious "modified" changes and clipping the real highlights.
- **Page numbers** and other page-fixed furniture are flagged as removed+added because, being page-anchored, they can't align inside a reflowing stream.

**What this PR does**

- **Whole-document mode**: concatenates all pages' body text into one reflow-aware stream, diffs once, and attributes each change back to its page, so the side-by-side viewer, highlight overlays, filters, navigation and PDF export all keep working. Content that merely reflows onto another page is no longer flagged. Ships behind a `Per-page` / `Whole document` toggle; per-page remains the default (non-destructive).
- **Page-fixed content handling**: at extraction, glyphs are classified body vs background (marked-content `Artifact`, font-scale outlier, off-axis rotation) and only body glyphs are merged into lines, so watermark glyphs no longer glue onto body words. In whole-document mode, page-fixed content (background layer, header/footer zone, cross-page repeated) is kept out of the reflow stream and diffed per page instead — genuine furniture changes still surface.
- An **"Ignore headers & watermarks"** toggle (default on) controls the document-level exclusion, as an escape hatch to view everything unfiltered.

All new type fields are optional, so per-page mode and existing behaviour are unchanged.

Fixes # (no pre-existing issue — happy to file one if preferred)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### 🧪 How Has This Been Tested?

**Checklist:**

- [x] Verified output manually
- [x] Tested with relevant sample documents or data
- [x] Wrote Vite Test Case (if applicable)

**Expected Results:**

- Whole-document mode: an early edit that reflows later pages shows only the real change, not per-page churn. Watermark (`CONCEPT`) and page numbers no longer appear as changes; body words are not corrupted with watermark letters; real-diff highlights are not clipped.

**Actual Results:**

- Confirmed on two real multi-page deeds (near-identical versions with an early edit): per-page mode shows many downstream false positives, whole-document mode shows only the genuine edits; the watermark and page-number false positives are gone and highlights render correctly.
- New Vitest suites: `src/tests/compare/compare-document.test.ts` (reflow suppression, page attribution, cross-page move split, furniture exclusion, ignore-furniture toggle) and `src/tests/compare/fixed-layer.test.ts` (layer classifiers, body-only merge guard, cross-page repetition). All compare tests pass; `tsc --noEmit`, `eslint`, and `vite build` are clean. (Two unrelated `split-pdf-helpers` real-qpdf tests fail on the unmodified tree as well.)

### Checklist:

- [x] I have signed the [Contributor License Agreement (CLA)](ICLA.md) or my organization has signed the [Corporate CLA](CCLA.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (n/a)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added whole-document comparison alongside per-page comparison.
  * Added controls to ignore headers, footers, watermarks, and other fixed content.
  * Improved page attribution for changes spanning multiple pages.
  * Comparison exports now support whole-document results.
* **Bug Fixes**
  * Reduced false positives from repeated page furniture and cross-page text movement.
  * Improved handling of rotated, oversized, artifact, and background text during comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
