### PR TITLE
feat(preview): add adjustable page preview size

### DIFF
--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -122,6 +122,12 @@
     "downloadAsPdf": "Als PDF herunterladen",
     "close": "Schließen"
   },
+  "previewSize": {
+    "label": "Vorschaugröße",
+    "small": "Klein",
+    "medium": "Mittel",
+    "large": "Groß"
+  },
   "settings": {
     "title": "Einstellungen",
     "shortcuts": "Tastenkürzel",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -122,6 +122,12 @@
     "downloadAsPdf": "Download as PDF",
     "close": "Close"
   },
+  "previewSize": {
+    "label": "Preview size",
+    "small": "Small",
+    "medium": "Medium",
+    "large": "Large"
+  },
   "settings": {
     "title": "Settings",
     "shortcuts": "Shortcuts",

--- a/src/js/logic/organize-pdf-page.ts
+++ b/src/js/logic/organize-pdf-page.ts
@@ -29,6 +29,33 @@ const organizeState: OrganizeState = {
   sortableInstance: null,
 };
 
+const PREVIEW_SIZE_KEY = 'previewSize';
+const DEFAULT_SIZE = 'small';
+const SIZE_CLASSES: Record<string, string> = {
+  small: 'grid grid-cols-4 sm:grid-cols-5 md:grid-cols-7 gap-3',
+  medium: 'grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-4',
+  large: 'grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4',
+};
+
+function applyPreviewSize(size: string): void {
+  const grid = document.getElementById('page-grid');
+  if (!grid) return;
+  const hidden = grid.classList.contains('hidden');
+  grid.className = SIZE_CLASSES[size] ?? SIZE_CLASSES[DEFAULT_SIZE];
+  if (hidden) grid.classList.add('hidden');
+
+  document.querySelectorAll('.preview-size-btn').forEach((btn) => {
+    const active = btn.getAttribute('data-size') === size;
+    btn.classList.toggle('bg-indigo-600', active);
+    btn.classList.toggle('text-white', active);
+    btn.classList.toggle('hover:bg-indigo-700', active);
+  });
+}
+
+function currentPreviewSize(): string {
+  return localStorage.getItem(PREVIEW_SIZE_KEY) || DEFAULT_SIZE;
+}
+
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', initializePage);
 } else {
@@ -72,6 +99,20 @@ function initializePage() {
 
   const applyOrderBtn = document.getElementById('apply-order-btn');
   if (applyOrderBtn) applyOrderBtn.addEventListener('click', applyCustomOrder);
+
+  const sizeGroup = document.getElementById('preview-size-group');
+  if (sizeGroup) {
+    sizeGroup.addEventListener('click', (e) => {
+      const btn = (e.target as HTMLElement).closest(
+        '.preview-size-btn'
+      ) as HTMLElement | null;
+      if (!btn) return;
+      const size = btn.getAttribute('data-size') || DEFAULT_SIZE;
+      localStorage.setItem(PREVIEW_SIZE_KEY, size);
+      applyPreviewSize(size);
+    });
+    applyPreviewSize(currentPreviewSize());
+  }
 }
 
 function applyCustomOrder() {
@@ -273,6 +314,8 @@ async function renderThumbnails() {
   grid.classList.remove('hidden');
   processBtn.classList.remove('hidden');
   advancedSettings.classList.remove('hidden');
+  document.getElementById('preview-size-toolbar')?.classList.remove('hidden');
+  applyPreviewSize(currentPreviewSize());
 
   for (let i = 1; i <= organizeState.totalPages; i++) {
     const page = await organizeState.pdfJsDoc.getPage(i);
@@ -414,6 +457,7 @@ function resetState() {
   }
   document.getElementById('process-btn')?.classList.add('hidden');
   document.getElementById('advanced-settings')?.classList.add('hidden');
+  document.getElementById('preview-size-toolbar')?.classList.add('hidden');
   const fileDisplayArea = document.getElementById('file-display-area');
   if (fileDisplayArea) fileDisplayArea.innerHTML = '';
 }

--- a/src/js/logic/organize-pdf-page.ts
+++ b/src/js/logic/organize-pdf-page.ts
@@ -46,6 +46,7 @@ function applyPreviewSize(size: string): void {
 
   document.querySelectorAll('.preview-size-btn').forEach((btn) => {
     const active = btn.getAttribute('data-size') === size;
+    btn.setAttribute('aria-pressed', active ? 'true' : 'false');
     btn.classList.toggle('bg-indigo-600', active);
     btn.classList.toggle('text-white', active);
     btn.classList.toggle('hover:bg-indigo-700', active);

--- a/src/js/logic/pdf-multi-tool.ts
+++ b/src/js/logic/pdf-multi-tool.ts
@@ -23,6 +23,36 @@ pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
 import { t } from '../i18n/i18n';
 import { loadPdfDocument } from '../utils/load-pdf-document.js';
 
+const PREVIEW_SIZE_KEY = 'previewSize';
+const DEFAULT_SIZE = 'small';
+const SIZE_CLASSES: Record<string, string> = {
+  small:
+    'grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-7 xl:grid-cols-8 gap-2 sm:gap-3',
+  medium:
+    'grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3 sm:gap-4',
+  large:
+    'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 gap-3 sm:gap-4',
+};
+
+function applyPreviewSize(size: string): void {
+  const grid = document.getElementById('pages-container');
+  if (!grid) return;
+  const hidden = grid.classList.contains('hidden');
+  grid.className = SIZE_CLASSES[size] ?? SIZE_CLASSES[DEFAULT_SIZE];
+  if (hidden) grid.classList.add('hidden');
+
+  document.querySelectorAll('.preview-size-btn').forEach((btn) => {
+    const active = btn.getAttribute('data-size') === size;
+    btn.classList.toggle('bg-indigo-600', active);
+    btn.classList.toggle('text-white', active);
+    btn.classList.toggle('hover:bg-indigo-700', active);
+  });
+}
+
+function currentPreviewSize(): string {
+  return localStorage.getItem(PREVIEW_SIZE_KEY) || DEFAULT_SIZE;
+}
+
 interface PageData {
   id: string; // Unique ID for DOM reconciliation
   pdfIndex: number;
@@ -341,6 +371,20 @@ function initializeTool() {
     }
   });
 
+  const sizeGroup = document.getElementById('preview-size-group');
+  if (sizeGroup) {
+    sizeGroup.addEventListener('click', (e) => {
+      const btn = (e.target as HTMLElement).closest(
+        '.preview-size-btn'
+      ) as HTMLElement | null;
+      if (!btn) return;
+      const size = btn.getAttribute('data-size') || DEFAULT_SIZE;
+      localStorage.setItem(PREVIEW_SIZE_KEY, size);
+      applyPreviewSize(size);
+    });
+    applyPreviewSize(currentPreviewSize());
+  }
+
   setupGlobalDragAndDrop();
 
   document.getElementById('upload-area')?.classList.remove('hidden');
@@ -586,6 +630,7 @@ async function loadPdfs(files: File[]) {
             batchSize: 8,
             useLazyLoading: true,
             lazyLoadMargin: '400px',
+            scale: 1,
             onProgress: (current, total) => {
               showLoading(current, total);
             },
@@ -656,11 +701,11 @@ function createPageElement(
 
   const preview = document.createElement('div');
   preview.className =
-    'bg-white rounded mb-2 overflow-hidden w-full flex items-center justify-center relative h-36 sm:h-64';
+    'page-preview-box bg-white rounded mb-2 overflow-hidden w-full flex items-center justify-center relative min-h-32';
 
   if (canvas) {
     const previewCanvas = canvas;
-    previewCanvas.className = 'max-w-full max-h-full object-contain';
+    previewCanvas.className = 'max-w-full h-auto block object-contain';
 
     previewCanvas.style.transform = `rotate(${pageData.visualRotation}deg)`;
     previewCanvas.style.transition = 'transform 0.2s ease';

--- a/src/js/logic/pdf-multi-tool.ts
+++ b/src/js/logic/pdf-multi-tool.ts
@@ -43,6 +43,7 @@ function applyPreviewSize(size: string): void {
 
   document.querySelectorAll('.preview-size-btn').forEach((btn) => {
     const active = btn.getAttribute('data-size') === size;
+    btn.setAttribute('aria-pressed', active ? 'true' : 'false');
     btn.classList.toggle('bg-indigo-600', active);
     btn.classList.toggle('text-white', active);
     btn.classList.toggle('hover:bg-indigo-700', active);

--- a/src/js/utils/render-utils.ts
+++ b/src/js/utils/render-utils.ts
@@ -17,6 +17,7 @@ export interface RenderConfig {
   onPageRendered?: (pageIndex: number, element: HTMLElement) => void;
   onBatchComplete?: () => void;
   shouldCancel?: () => boolean;
+  scale?: number;
 }
 
 /**
@@ -275,6 +276,7 @@ export async function renderPagesProgressively(
     eagerLoadBatches = 2,
     onProgress,
     onBatchComplete,
+    scale,
   } = config;
 
   const totalPages = pdfjsDoc.numPages;
@@ -298,7 +300,7 @@ export async function renderPagesProgressively(
       pageNumber: i,
       pdfjsDoc,
       container,
-      scale: useLazyLoading ? 0.5 : 1,
+      scale: scale ?? (useLazyLoading ? 0.5 : 1),
       createWrapper,
       placeholderElement: placeholders[i - 1],
     });

--- a/src/pages/organize-pdf.html
+++ b/src/pages/organize-pdf.html
@@ -164,10 +164,46 @@
         <!-- File Display -->
         <div id="file-display-area" class="mt-4 space-y-2"></div>
 
+        <!-- Preview Size Control -->
+        <div
+          id="preview-size-toolbar"
+          class="hidden mt-6 mb-2 flex items-center justify-end gap-2"
+        >
+          <span class="text-sm text-gray-400 mr-1" data-i18n="previewSize.label"
+            >Preview size</span
+          >
+          <div
+            class="inline-flex rounded-lg overflow-hidden border border-gray-600"
+            id="preview-size-group"
+          >
+            <button
+              data-size="small"
+              data-i18n="previewSize.small"
+              class="preview-size-btn px-3 py-1.5 text-sm text-gray-300 hover:bg-gray-700 transition-colors"
+            >
+              Small
+            </button>
+            <button
+              data-size="medium"
+              data-i18n="previewSize.medium"
+              class="preview-size-btn px-3 py-1.5 text-sm text-gray-300 hover:bg-gray-700 transition-colors border-l border-gray-600"
+            >
+              Medium
+            </button>
+            <button
+              data-size="large"
+              data-i18n="previewSize.large"
+              class="preview-size-btn px-3 py-1.5 text-sm text-gray-300 hover:bg-gray-700 transition-colors border-l border-gray-600"
+            >
+              Large
+            </button>
+          </div>
+        </div>
+
         <!-- Page Grid (shown after file upload) -->
         <div
           id="page-grid"
-          class="hidden grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-4 my-6"
+          class="hidden grid grid-cols-4 sm:grid-cols-5 md:grid-cols-7 gap-3"
         ></div>
 
         <!-- Advanced Settings -->

--- a/src/pages/pdf-multi-tool.html
+++ b/src/pages/pdf-multi-tool.html
@@ -407,6 +407,42 @@
           </button>
         </div>
 
+        <!-- Preview Size Control -->
+        <div
+          id="preview-size-toolbar"
+          class="flex items-center justify-end gap-2 mb-3"
+        >
+          <span class="text-sm text-gray-400 mr-1" data-i18n="previewSize.label"
+            >Preview size</span
+          >
+          <div
+            class="inline-flex rounded-lg overflow-hidden border border-gray-600"
+            id="preview-size-group"
+          >
+            <button
+              data-size="small"
+              data-i18n="previewSize.small"
+              class="preview-size-btn px-3 py-1.5 text-sm text-gray-300 hover:bg-gray-700 transition-colors"
+            >
+              Small
+            </button>
+            <button
+              data-size="medium"
+              data-i18n="previewSize.medium"
+              class="preview-size-btn px-3 py-1.5 text-sm text-gray-300 hover:bg-gray-700 transition-colors border-l border-gray-600"
+            >
+              Medium
+            </button>
+            <button
+              data-size="large"
+              data-i18n="previewSize.large"
+              class="preview-size-btn px-3 py-1.5 text-sm text-gray-300 hover:bg-gray-700 transition-colors border-l border-gray-600"
+            >
+              Large
+            </button>
+          </div>
+        </div>
+
         <div
           id="pages-container"
           class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3 sm:gap-4"


### PR DESCRIPTION
### Description

Adds an adjustable page-preview size control to the Duplicate & Organize and PDF Multi Tool pages.

No new dependencies.

Fixes #301

### Type of change

- [X] New feature (non-breaking change which adds functionality)

### 🧪 How Has This Been Tested?

Manual testing in the browser:

- Uploaded multi-page PDFs to both /organize-pdf and /pdf-multi-tool.
- Toggled Preview size: grid density and preview size change accordingly, and previews enlarge.
- Verified text stays sharp at larger sizes.

Automated checks:

- `npm run lint` → 0 errors (no new warnings introduced).
- `npm run build` → succeeds (i18n page generation, sitemap, security headers,
  SEO audit all green).

**Checklist:**

- [X] Verified output manually
- [X] Tested with relevant sample documents or data
- [ ] Wrote Vite Test Case (if applicable)

**Expected Results:**

- Preview size changes on demand.

**Actual Results:**

- As expected.

### Checklist:

- [X] I have signed the [Contributor License Agreement (CLA)](ICLA.md) or my organization has signed the [Corporate CLA](CCLA.md)
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Preview size” controls (Small/Medium/Large) to the PDF tools, with English and German labels.
  * Remember the selected preview size and restore it automatically when returning to the tool.
* **UI Updates**
  * Refreshed the page preview grid and preview card/canvas sizing for more consistent, responsive display.
* **Rendering**
  * Page preview rendering now uses an explicit/configurable scale setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->