### PR TITLE
Make organize PDF page previews larger

### DIFF
--- a/src/pages/organize-pdf.html
+++ b/src/pages/organize-pdf.html
@@ -167,7 +167,7 @@
         <!-- Page Grid (shown after file upload) -->
         <div
           id="page-grid"
-          class="hidden grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 my-6"
+          class="hidden grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 my-6"
         ></div>
 
         <!-- Advanced Settings -->

--- a/src/pages/organize-pdf.html
+++ b/src/pages/organize-pdf.html
@@ -103,7 +103,7 @@
     >
       <div
         id="tool-uploader"
-        class="bg-gray-800 rounded-xl shadow-xl px-4 py-8 md:p-8 max-w-2xl w-full text-gray-200 border border-gray-700"
+        class="bg-gray-800 rounded-xl shadow-xl px-4 py-8 md:p-8 max-w-7xl w-full text-gray-200 border border-gray-700"
       >
         <button
           id="back-to-tools"
@@ -167,7 +167,7 @@
         <!-- Page Grid (shown after file upload) -->
         <div
           id="page-grid"
-          class="hidden grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-4 my-6"
+          class="hidden grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 my-6"
         ></div>
 
         <!-- Advanced Settings -->


### PR DESCRIPTION
### Description

Makes page thumbnails on the Organize PDF tool substantially larger so users can identify page contents before reordering.

- Expands the organizer workspace from `max-w-2xl` to `max-w-7xl`
- Uses one preview per row on phones, two on tablets, and three on desktop
- Increases spacing between previews for clearer drag-and-drop targets

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### 🧪 How Has This Been Tested?

- [x] Verified output manually
- [x] Ran the full production build
- [x] Confirmed Prettier formatting and `git diff --check`

**Expected Results:** Page previews are large enough to identify their contents across responsive breakpoints.

**Actual Results:** The responsive grid renders larger previews and the complete build, generated i18n pages, sitemap generation, security-header generation, and SEO audit pass.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings attributable to this change
- [x] New and existing build checks pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Widened the tool uploader area for improved visibility.
  * Updated the page layout to use a more spacious, responsive grid across screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->