### PR TITLE
Update nl/tools.json

### DIFF
--- a/public/locales/nl/tools.json
+++ b/public/locales/nl/tools.json
@@ -103,7 +103,7 @@
     "statusReadingFileMainThread": "Bestand lezen (Hoofdthread)...",
     "statusGenerating": "Inhoudsopgave genereren...",
     "errorReadingFileWithMessage": "Fout bij lezen bestand: {{message}}",
-    "successGeneratedDownloadStarted": "Inhoudsopgave succesvol gegenereerd! Download gestart.",
+    "successGeneratedDownloadStarted": "Inhoudsopgave met succes gegenereerd! Download gestart.",
     "workerErrorWithMessage": "Fout: {{message}}",
     "workerErrorOccurred": "Er is een worker-fout opgetreden. Controleer de console voor details."
   },
@@ -159,7 +159,7 @@
     "invalidRangeMessage": "Regel {{number}} heeft een ongeldig paginabereik: {{range}}",
     "allPages": "alle pagina's",
     "emptyOutputMessage": "CoherentPDF heeft een leeg bestand geproduceerd.",
-    "successMessage": "Paginalabels zijn succesvol toegevoegd!",
+    "successMessage": "Paginalabels zijn met succes toegevoegd!",
     "processErrorMessage": "Kon de paginalabels niet toevoegen.",
     "styleOptions": {
       "DecimalArabic": "Decimale cijfers",
@@ -310,7 +310,7 @@
       "converting": "JSON-bestanden naar PDF converteren...",
       "readError": "Fout bij lezen bestanden: {{message}}",
       "creatingZip": "ZIP-bestand maken...",
-      "success": "JSON-bestanden succesvol naar PDF geconverteerd! ZIP-download gestart.",
+      "success": "JSON-bestanden met succes naar PDF geconverteerd! ZIP-download gestart.",
       "zipError": "Fout bij maken ZIP: {{message}}",
       "workerError": "Worker-fout: {{message}}",
       "getStarted": "Selecteer JSON-bestanden om te beginnen"
@@ -428,7 +428,7 @@
       "invalidFileExplanation": "Upload een PDF-bestand.",
       "noFile": "Geen bestand",
       "noFileExplanation": "Upload eerst een PDF-bestand.",
-      "conversionSuccess": "PDF succesvol geconverteerd naar CBZ!",
+      "conversionSuccess": "PDF met succes geconverteerd naar CBZ!",
       "conversionError": "Kan PDF niet converteren naar CBZ. Het bestand is mogelijk beschadigd."
     }
   },
@@ -448,7 +448,7 @@
       "converting": "PDF's naar JSON converteren...",
       "readError": "Fout bij lezen bestanden: {{message}}",
       "creatingZip": "ZIP-bestand maken...",
-      "success": "PDF's succesvol naar JSON geconverteerd! ZIP-download gestart.",
+      "success": "PDF's met succes naar JSON geconverteerd! ZIP-download gestart.",
       "zipError": "Fout bij maken ZIP: {{message}}",
       "workerError": "Worker-fout: {{message}}",
       "getStarted": "Selecteer PDF-bestanden om te beginnen"
@@ -942,7 +942,7 @@
     "tsaSectionTitle": "Tijdstempelserver (TSA)",
     "selectTsa": "Selecteer een TSA-server",
     "applyTimestamp": "Tijdstempel toepassen",
-    "successMessage": "PDF succesvol voorzien van tijdstempel! Het tijdstempel kan in elke PDF-lezer worden geverifieerd."
+    "successMessage": "PDF met succes voorzien van tijdstempel! Het tijdstempel kan in elke PDF-lezer worden geverifieerd."
   },
   "emailToPdf": {
     "name": "E-mail naar PDF",
@@ -1109,7 +1109,7 @@
     "saveConfiguration": "Configuratie opslaan",
     "savingConfiguration": "Configuratie opslaan...",
     "savedTitle": "Opgeslagen",
-    "savedMessage": "Configuratie succesvol opgeslagen!",
+    "savedMessage": "Configuratie met succes opgeslagen!",
     "errorTitle": "Fout",
     "failedSave": "Kon configuratie niet opslaan: {{message}}",
     "emptyUrlTitle": "Lege URL",


### PR DESCRIPTION
Consistency: "successfully" = "met succes"
"succesvol" is an Angicism



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated seven Dutch success messages to use more natural wording: “met succes” instead of “succesvol”.
  * No functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->