### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ BentoPDF does **not** bundle AGPL-licensed processing libraries in its source co
 
 ## ⭐ Stargazers over time
 
-[![Star History Chart](https://api.star-history.com/svg?repos=alam00000/bentopdf&type=Date)](https://star-history.com/#alam00000/bentopdf&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=alam00000/bentopdf&type=Date)](https://star-history.dera.page/#alam00000/bentopdf&Date)
 
 ---
 


### PR DESCRIPTION
The star history chart in the README is currently broken because it relies on an API restricted by GitHub's stargazer API limits. This change points the chart to a working data source so the stargazer history displays correctly once more.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History Chart badge and link to use the new `star-history.dera.page` address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->