### PR TITLE
fix(navigation): respect BASE_URL in tool pages and navbar brand (Fixes #850)

### DIFF
--- a/simple-index.html
+++ b/simple-index.html
@@ -60,7 +60,7 @@
               class="h-8 w-8"
             />
             <span class="text-white font-bold text-xl ml-2">
-              <a href="/"
+              <a href="{{baseUrl}}"
                 >{{#if brandName}}{{brandName}}{{else}}BentoPDF{{/if}}</a
               >
             </span>

--- a/src/js/logic/deskew-pdf-page.ts
+++ b/src/js/logic/deskew-pdf-page.ts
@@ -273,7 +273,7 @@ function initPage(): void {
 
   if (backBtn) {
     backBtn.addEventListener('click', () => {
-      window.location.href = '/';
+      window.location.href = import.meta.env.BASE_URL;
     });
   }
 

--- a/src/js/logic/form-filler-page.ts
+++ b/src/js/logic/form-filler-page.ts
@@ -311,6 +311,6 @@ document.addEventListener('DOMContentLoaded', () => {
   processBtn?.addEventListener('click', processAndDownloadForm);
 
   backBtn?.addEventListener('click', () => {
-    window.location.href = '../../index.html';
+    window.location.href = import.meta.env.BASE_URL;
   });
 });

--- a/src/js/logic/markdown-to-pdf-page.ts
+++ b/src/js/logic/markdown-to-pdf-page.ts
@@ -1,21 +1,21 @@
 import { MarkdownEditor } from '../utils/markdown-editor.js';
 
 document.addEventListener('DOMContentLoaded', () => {
-    const container = document.getElementById('markdown-editor-container');
+  const container = document.getElementById('markdown-editor-container');
 
-    if (!container) {
-        console.error('Markdown editor container not found');
-        return;
-    }
+  if (!container) {
+    console.error('Markdown editor container not found');
+    return;
+  }
 
-    const editor = new MarkdownEditor(container, {});
+  const editor = new MarkdownEditor(container, {});
 
-    console.log('Markdown editor initialized');
+  console.log('Markdown editor initialized');
 
-    const backButton = document.getElementById('back-to-tools');
-    if (backButton) {
-        backButton.addEventListener('click', () => {
-            window.location.href = '/';
-        });
-    }
+  const backButton = document.getElementById('back-to-tools');
+  if (backButton) {
+    backButton.addEventListener('click', () => {
+      window.location.href = import.meta.env.BASE_URL;
+    });
+  }
 });

--- a/src/js/logic/remove-annotations-page.ts
+++ b/src/js/logic/remove-annotations-page.ts
@@ -189,6 +189,6 @@ document.addEventListener('DOMContentLoaded', () => {
   processBtn?.addEventListener('click', processRemoveAnnotations);
 
   backBtn?.addEventListener('click', () => {
-    window.location.href = '../../index.html';
+    window.location.href = import.meta.env.BASE_URL;
   });
 });

--- a/src/js/logic/remove-blank-pages-page.ts
+++ b/src/js/logic/remove-blank-pages-page.ts
@@ -366,6 +366,6 @@ document.addEventListener('DOMContentLoaded', () => {
   processBtn?.addEventListener('click', processRemoveBlankPages);
 
   document.getElementById('back-to-tools')?.addEventListener('click', () => {
-    window.location.href = '../../index.html';
+    window.location.href = import.meta.env.BASE_URL;
   });
 });

--- a/src/pages/pdf-multi-tool.html
+++ b/src/pages/pdf-multi-tool.html
@@ -134,7 +134,7 @@
               class="h-8 w-8"
             />
             <span class="text-white font-bold text-xl ml-2">
-              <a href="/"
+              <a href="{{baseUrl}}"
                 >{{#if brandName}}{{brandName}}{{else}}BentoPDF{{/if}}</a
               >
             </span>

--- a/src/tests/navigation-base-url.test.ts
+++ b/src/tests/navigation-base-url.test.ts
@@ -7,89 +7,84 @@ describe('Navigation BASE_URL Consistency', () => {
   const pagesDir = path.resolve(__dirname, '../pages');
   const rootDir = path.resolve(__dirname, '../../');
 
-  it('ensures no tool logic files hardcode root "/" or relative paths for navigation', () => {
+  it('ensures tool navigation assignments strictly use import.meta.env.BASE_URL', () => {
     const files = fs
       .readdirSync(logicDir)
-      .filter((file) => file.endsWith('.ts') || file.endsWith('.js'));
+      .filter(
+        (file) =>
+          (file.endsWith('.ts') || file.endsWith('.js')) &&
+          file !== 'shortcuts.ts'
+      );
 
-    const offendingFiles: string[] = [];
+    const nonCompliantAssignments: Array<{ file: string; target: string }> = [];
 
     for (const file of files) {
       const content = fs.readFileSync(path.join(logicDir, file), 'utf-8');
+      const assignments = content.matchAll(
+        /window\.location\.href\s*=\s*([^;\n]+)/g
+      );
 
-      // Check for hardcoded root redirects or relative path escapes
-      if (
-        /window\.location\.href\s*=\s*['"`]\/['"`]/.test(content) ||
-        /window\.location\.href\s*=\s*['"`]\.\.\//.test(content)
-      ) {
-        offendingFiles.push(file);
+      for (const match of assignments) {
+        const target = match[1].trim();
+        if (!target.includes('import.meta.env.BASE_URL')) {
+          nonCompliantAssignments.push({ file, target });
+        }
       }
     }
 
     expect(
-      offendingFiles,
-      `The following files hardcode root or relative navigation instead of import.meta.env.BASE_URL: ${offendingFiles.join(
-        ', '
+      nonCompliantAssignments,
+      `The following files assign window.location.href without import.meta.env.BASE_URL: ${JSON.stringify(
+        nonCompliantAssignments,
+        null,
+        2
       )}`
     ).toEqual([]);
   });
 
-  it('ensures tool logic files with back-to-tools button use import.meta.env.BASE_URL', () => {
-    const files = fs
-      .readdirSync(logicDir)
-      .filter((file) => file.endsWith('.ts') || file.endsWith('.js'));
+  it('ensures each affected back-button handler assigns import.meta.env.BASE_URL', () => {
+    const affectedFiles = [
+      'deskew-pdf-page.ts',
+      'markdown-to-pdf-page.ts',
+      'remove-annotations-page.ts',
+      'form-filler-page.ts',
+      'remove-blank-pages-page.ts',
+    ];
 
-    const filesMissingBaseUrl: string[] = [];
-
-    for (const file of files) {
+    for (const file of affectedFiles) {
       const content = fs.readFileSync(path.join(logicDir, file), 'utf-8');
-
-      // If the file handles 'back-to-tools' click navigation
-      if (
-        content.includes('back-to-tools') &&
-        content.includes('window.location.href') &&
-        !content.includes('import.meta.env.BASE_URL')
-      ) {
-        filesMissingBaseUrl.push(file);
-      }
+      expect(
+        content,
+        `${file} must assign window.location.href to import.meta.env.BASE_URL`
+      ).toMatch(/window\.location\.href\s*=\s*import\.meta\.env\.BASE_URL/);
     }
-
-    expect(
-      filesMissingBaseUrl,
-      `The following files handle back-to-tools navigation without import.meta.env.BASE_URL: ${filesMissingBaseUrl.join(
-        ', '
-      )}`
-    ).toEqual([]);
   });
 
-  it('ensures HTML templates do not hardcode href="/" for brand links', () => {
-    const htmlFiles = fs
-      .readdirSync(pagesDir)
-      .filter((file) => file.endsWith('.html'))
-      .map((file) => path.join(pagesDir, file));
+  it('ensures brand anchor in standalone templates asserts href="{{baseUrl}}"', () => {
+    const standaloneTemplates = [
+      path.join(pagesDir, 'pdf-multi-tool.html'),
+      path.join(rootDir, 'simple-index.html'),
+      path.join(rootDir, 'src/partials/navbar-simple.html'),
+    ];
 
-    const simpleIndex = path.join(rootDir, 'simple-index.html');
-    if (fs.existsSync(simpleIndex)) {
-      htmlFiles.push(simpleIndex);
-    }
+    for (const filePath of standaloneTemplates) {
+      if (!fs.existsSync(filePath)) continue;
 
-    const offendingFiles: string[] = [];
-
-    for (const filePath of htmlFiles) {
       const content = fs.readFileSync(filePath, 'utf-8');
+      const brandAnchorMatch = content.match(
+        /<a\s+[^>]*href=["']([^"']*)["'][^>]*>[\s\S]*?(?:{{#if\s+brandName}}|BentoPDF)/i
+      );
 
-      // Brand link / logo anchor should not be hardcoded to href="/"
-      // e.g. <a href="/"> should be <a href="{{baseUrl}}">
-      if (/<a\s+[^>]*href=["']\/["'][^>]*>.*BentoPDF/i.test(content)) {
-        offendingFiles.push(path.basename(filePath));
-      }
+      expect(
+        brandAnchorMatch,
+        `Could not locate brand anchor in ${path.basename(filePath)}`
+      ).not.toBeNull();
+
+      const href = brandAnchorMatch?.[1];
+      expect(
+        href,
+        `Expected ${path.basename(filePath)} brand anchor href to be "{{baseUrl}}" but got "${href}"`
+      ).toBe('{{baseUrl}}');
     }
-
-    expect(
-      offendingFiles,
-      `The following HTML templates hardcode href="/" for the brand link: ${offendingFiles.join(
-        ', '
-      )}`
-    ).toEqual([]);
   });
 });

--- a/src/tests/navigation-base-url.test.ts
+++ b/src/tests/navigation-base-url.test.ts
@@ -71,16 +71,22 @@ describe('Navigation BASE_URL Consistency', () => {
       if (!fs.existsSync(filePath)) continue;
 
       const content = fs.readFileSync(filePath, 'utf-8');
-      const brandAnchorMatch = content.match(
-        /<a\s+[^>]*href=["']([^"']*)["'][^>]*>[\s\S]*?(?:{{#if\s+brandName}}|BentoPDF)/i
+      const anchors = [
+        ...content.matchAll(
+          /<a\b[^>]*href=["']([^"']*)["'][^>]*>([\s\S]*?)<\/a\s*>/gi
+        ),
+      ];
+
+      const brandAnchor = anchors.find(([, , innerContent]) =>
+        /{{#if\s+brandName}}|BentoPDF/i.test(innerContent)
       );
 
       expect(
-        brandAnchorMatch,
+        brandAnchor,
         `Could not locate brand anchor in ${path.basename(filePath)}`
-      ).not.toBeNull();
+      ).toBeDefined();
 
-      const href = brandAnchorMatch?.[1];
+      const href = brandAnchor?.[1];
       expect(
         href,
         `Expected ${path.basename(filePath)} brand anchor href to be "{{baseUrl}}" but got "${href}"`

--- a/src/tests/navigation-base-url.test.ts
+++ b/src/tests/navigation-base-url.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('Navigation BASE_URL Consistency', () => {
+  const logicDir = path.resolve(__dirname, '../js/logic');
+  const pagesDir = path.resolve(__dirname, '../pages');
+  const rootDir = path.resolve(__dirname, '../../');
+
+  it('ensures no tool logic files hardcode root "/" or relative paths for navigation', () => {
+    const files = fs
+      .readdirSync(logicDir)
+      .filter((file) => file.endsWith('.ts') || file.endsWith('.js'));
+
+    const offendingFiles: string[] = [];
+
+    for (const file of files) {
+      const content = fs.readFileSync(path.join(logicDir, file), 'utf-8');
+
+      // Check for hardcoded root redirects or relative path escapes
+      if (
+        /window\.location\.href\s*=\s*['"`]\/['"`]/.test(content) ||
+        /window\.location\.href\s*=\s*['"`]\.\.\//.test(content)
+      ) {
+        offendingFiles.push(file);
+      }
+    }
+
+    expect(
+      offendingFiles,
+      `The following files hardcode root or relative navigation instead of import.meta.env.BASE_URL: ${offendingFiles.join(
+        ', '
+      )}`
+    ).toEqual([]);
+  });
+
+  it('ensures tool logic files with back-to-tools button use import.meta.env.BASE_URL', () => {
+    const files = fs
+      .readdirSync(logicDir)
+      .filter((file) => file.endsWith('.ts') || file.endsWith('.js'));
+
+    const filesMissingBaseUrl: string[] = [];
+
+    for (const file of files) {
+      const content = fs.readFileSync(path.join(logicDir, file), 'utf-8');
+
+      // If the file handles 'back-to-tools' click navigation
+      if (
+        content.includes('back-to-tools') &&
+        content.includes('window.location.href') &&
+        !content.includes('import.meta.env.BASE_URL')
+      ) {
+        filesMissingBaseUrl.push(file);
+      }
+    }
+
+    expect(
+      filesMissingBaseUrl,
+      `The following files handle back-to-tools navigation without import.meta.env.BASE_URL: ${filesMissingBaseUrl.join(
+        ', '
+      )}`
+    ).toEqual([]);
+  });
+
+  it('ensures HTML templates do not hardcode href="/" for brand links', () => {
+    const htmlFiles = fs
+      .readdirSync(pagesDir)
+      .filter((file) => file.endsWith('.html'))
+      .map((file) => path.join(pagesDir, file));
+
+    const simpleIndex = path.join(rootDir, 'simple-index.html');
+    if (fs.existsSync(simpleIndex)) {
+      htmlFiles.push(simpleIndex);
+    }
+
+    const offendingFiles: string[] = [];
+
+    for (const filePath of htmlFiles) {
+      const content = fs.readFileSync(filePath, 'utf-8');
+
+      // Brand link / logo anchor should not be hardcoded to href="/"
+      // e.g. <a href="/"> should be <a href="{{baseUrl}}">
+      if (/<a\s+[^>]*href=["']\/["'][^>]*>.*BentoPDF/i.test(content)) {
+        offendingFiles.push(path.basename(filePath));
+      }
+    }
+
+    expect(
+      offendingFiles,
+      `The following HTML templates hardcode href="/" for the brand link: ${offendingFiles.join(
+        ', '
+      )}`
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Description

When BentoPDF is deployed under a subpath using `BASE_URL` (e.g. `BASE_URL=/bentopdf/` in Docker / Nginx reverse proxy setups), several tools and templates did not respect the configured base path:

1. **Brand/Logo Navigation**:
   - `src/pages/pdf-multi-tool.html` and `simple-index.html` hardcoded `<a href="/">` instead of `<a href="{{baseUrl}}">`. Clicking the logo on these pages redirected users to the root domain instead of staying within BentoPDF.

2. **"Back to tools" Navigation**:
   - 5 tools (`deskew-pdf`, `markdown-to-pdf`, `remove-annotations`, `form-filler`, and `remove-blank-pages`) did not use `import.meta.env.BASE_URL`:
     - `deskew-pdf-page.ts` and `markdown-to-pdf-page.ts` hardcoded `window.location.href = '/'`.
     - `remove-annotations-page.ts`, `form-filler-page.ts`, and `remove-blank-pages-page.ts` hardcoded `window.location.href = '../../index.html'`.
   - Clicking "Back to tools" on these pages redirected to the server root domain, causing 404 errors in subpath deployments.

This PR updates all 5 tool pages to use `window.location.href = import.meta.env.BASE_URL;` (matching the other 60+ tools) and updates the templates to use `{{baseUrl}}`. An automated Vitest regression test suite (`src/tests/navigation-base-url.test.ts`) is also added to ensure all logic files and templates adhere to `BASE_URL`.

Fixes #850

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### 🧪 How Has This Been Tested?

Tested locally by compiling with `BASE_URL=/bentopdf/ npm run build:docker` and serving the build output under a subpath environment matching the Docker/Nginx file structure:
- Verified clicking the brand logo in `pdf-multi-tool.html` and `simple-index.html` navigates to `/bentopdf/` instead of `/`.
- Verified clicking "Back to tools" in `deskew-pdf`, `markdown-to-pdf`, `remove-annotations`, `form-filler`, and `remove-blank-pages` navigates to `/bentopdf/` instead of `/` or `../../index.html`.
- Verified automated Vitest test suite passes.

**Checklist:**

- [x] Verified output manually
- [x] Tested with relevant sample documents or data
- [x] Wrote Vite Test Case (if applicable)

**Expected Results:**

- Clicking "Back to tools" and the brand logo on all tool pages preserves the configured `BASE_URL` without 404 errors.
- Vitest automated tests pass cleanly.

**Actual Results:**

- All tool pages and templates stay within the configured `BASE_URL` subpath.
- All 49 test suites (925 tests) pass, including `src/tests/navigation-base-url.test.ts`.

### Checklist:

- [x] I have signed the [Contributor License Agreement (CLA)](ICLA.md) or my organization has signed the [Corporate CLA](CCLA.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation across PDF tools and the simple-mode interface when hosted under a configured base URL.
  * Updated brand links and “Back to tools” buttons to return to the correct application location instead of assuming the site is hosted at the root path.

* **Tests**
  * Added checks to help ensure navigation consistently respects the configured base URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->