### PR TITLE
feat: add drag-to-reorder file lists to image/text-to-PDF tools

### DIFF
--- a/src/js/logic/bmp-to-pdf-page.ts
+++ b/src/js/logic/bmp-to-pdf-page.ts
@@ -1,204 +1,194 @@
 import { showLoader, hideLoader, showAlert } from '../ui.js';
-import { downloadFile, formatBytes } from '../utils/helpers.js';
-import { createIcons, icons } from 'lucide';
+import { downloadFile } from '../utils/helpers.js';
+import {
+  renderReorderableFileList,
+  destroyReorderableFileList,
+} from '../utils/reorderable-file-list.js';
 import { PDFDocument as PDFLibDocument } from 'pdf-lib';
 
 let files: File[] = [];
 
 async function convertImageToPngBytes(file: File): Promise<ArrayBuffer> {
-    return new Promise((resolve, reject) => {
-        const img = new Image();
-        const reader = new FileReader();
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    const reader = new FileReader();
 
-        reader.onload = (e) => {
-            img.onload = async () => {
-                const canvas = document.createElement('canvas');
-                canvas.width = img.width;
-                canvas.height = img.height;
-                const ctx = canvas.getContext('2d');
-                if (!ctx) {
-                    reject(new Error('Failed to get canvas context'));
-                    return;
-                }
-                ctx.drawImage(img, 0, 0);
-                const pngBlob = await new Promise<Blob | null>((res) =>
-                    canvas.toBlob(res, 'image/png')
-                );
-                if (!pngBlob) {
-                    reject(new Error('Failed to create PNG blob'));
-                    return;
-                }
-                const pngBytes = await pngBlob.arrayBuffer();
-                resolve(pngBytes);
-            };
-            img.onerror = () => reject(new Error('Failed to load image.'));
-            img.src = e.target?.result as string;
-        };
-        reader.onerror = () => reject(new Error('Failed to read file.'));
-        reader.readAsDataURL(file);
-    });
+    reader.onload = (e) => {
+      img.onload = async () => {
+        const canvas = document.createElement('canvas');
+        canvas.width = img.width;
+        canvas.height = img.height;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+          reject(new Error('Failed to get canvas context'));
+          return;
+        }
+        ctx.drawImage(img, 0, 0);
+        const pngBlob = await new Promise<Blob | null>((res) =>
+          canvas.toBlob(res, 'image/png')
+        );
+        if (!pngBlob) {
+          reject(new Error('Failed to create PNG blob'));
+          return;
+        }
+        const pngBytes = await pngBlob.arrayBuffer();
+        resolve(pngBytes);
+      };
+      img.onerror = () => reject(new Error('Failed to load image.'));
+      img.src = e.target?.result as string;
+    };
+    reader.onerror = () => reject(new Error('Failed to read file.'));
+    reader.readAsDataURL(file);
+  });
 }
 
 const updateUI = () => {
-    const fileDisplayArea = document.getElementById('file-display-area');
-    const fileControls = document.getElementById('file-controls');
-    const processBtn = document.getElementById('process-btn');
+  const fileDisplayArea = document.getElementById('file-display-area');
+  const fileControls = document.getElementById('file-controls');
+  const processBtn = document.getElementById('process-btn');
 
-    if (!fileDisplayArea || !fileControls || !processBtn) return;
+  if (!fileDisplayArea || !fileControls || !processBtn) return;
 
-    fileDisplayArea.innerHTML = '';
+  fileDisplayArea.innerHTML = '';
 
-    if (files.length > 0) {
-        fileControls.classList.remove('hidden');
-        processBtn.classList.remove('hidden');
+  if (files.length > 0) {
+    fileControls.classList.remove('hidden');
+    processBtn.classList.remove('hidden');
 
-        files.forEach((file, index) => {
-            const fileDiv = document.createElement('div');
-            fileDiv.className = 'flex items-center justify-between bg-gray-700 p-3 rounded-lg text-sm';
-
-            const infoContainer = document.createElement('div');
-            infoContainer.className = 'flex items-center gap-2 overflow-hidden';
-
-            const nameSpan = document.createElement('span');
-            nameSpan.className = 'truncate font-medium text-gray-200';
-            nameSpan.textContent = file.name;
-
-            const sizeSpan = document.createElement('span');
-            sizeSpan.className = 'flex-shrink-0 text-gray-400 text-xs';
-            sizeSpan.textContent = `(${formatBytes(file.size)})`;
-
-            infoContainer.append(nameSpan, sizeSpan);
-
-            const removeBtn = document.createElement('button');
-            removeBtn.className = 'ml-4 text-red-400 hover:text-red-300 flex-shrink-0';
-            removeBtn.innerHTML = '<i data-lucide="trash-2" class="w-4 h-4"></i>';
-            removeBtn.onclick = () => {
-                files = files.filter((_, i) => i !== index);
-                updateUI();
-            };
-
-            fileDiv.append(infoContainer, removeBtn);
-            fileDisplayArea.appendChild(fileDiv);
-        });
-        createIcons({ icons });
-    } else {
-        fileControls.classList.add('hidden');
-        processBtn.classList.add('hidden');
-    }
+    renderReorderableFileList({
+      container: fileDisplayArea,
+      files,
+      onReorder: (reordered) => {
+        files = reordered;
+      },
+      onRemove: (index) => {
+        files = files.filter((_, i) => i !== index);
+        updateUI();
+      },
+    });
+  } else {
+    destroyReorderableFileList(fileDisplayArea);
+    fileControls.classList.add('hidden');
+    processBtn.classList.add('hidden');
+  }
 };
 
 const resetState = () => {
-    files = [];
-    updateUI();
+  files = [];
+  updateUI();
 };
 
 async function convert() {
-    if (files.length === 0) {
-        showAlert('No Files', 'Please select at least one BMP file.');
-        return;
+  if (files.length === 0) {
+    showAlert('No Files', 'Please select at least one BMP file.');
+    return;
+  }
+  showLoader('Converting BMP to PDF...');
+  try {
+    const pdfDoc = await PDFLibDocument.create();
+    for (const file of files) {
+      const pngBytes = await convertImageToPngBytes(file);
+      const pngImage = await pdfDoc.embedPng(pngBytes);
+      const page = pdfDoc.addPage([pngImage.width, pngImage.height]);
+      page.drawImage(pngImage, {
+        x: 0,
+        y: 0,
+        width: pngImage.width,
+        height: pngImage.height,
+      });
     }
-    showLoader('Converting BMP to PDF...');
-    try {
-        const pdfDoc = await PDFLibDocument.create();
-        for (const file of files) {
-            const pngBytes = await convertImageToPngBytes(file);
-            const pngImage = await pdfDoc.embedPng(pngBytes);
-            const page = pdfDoc.addPage([pngImage.width, pngImage.height]);
-            page.drawImage(pngImage, {
-                x: 0,
-                y: 0,
-                width: pngImage.width,
-                height: pngImage.height,
-            });
-        }
-        const pdfBytes = await pdfDoc.save();
-        downloadFile(
-            new Blob([new Uint8Array(pdfBytes)], { type: 'application/pdf' }),
-            'from_bmps.pdf'
-        );
-        showAlert('Success', 'PDF created successfully!', 'success', () => {
-            resetState();
-        });
-    } catch (e) {
-        console.error(e);
-        showAlert(
-            'Error',
-            'Failed to convert BMP to PDF. One of the files may be invalid.'
-        );
-    } finally {
-        hideLoader();
-    }
+    const pdfBytes = await pdfDoc.save();
+    downloadFile(
+      new Blob([new Uint8Array(pdfBytes)], { type: 'application/pdf' }),
+      'from_bmps.pdf'
+    );
+    showAlert('Success', 'PDF created successfully!', 'success', () => {
+      resetState();
+    });
+  } catch (e) {
+    console.error(e);
+    showAlert(
+      'Error',
+      'Failed to convert BMP to PDF. One of the files may be invalid.'
+    );
+  } finally {
+    hideLoader();
+  }
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    const fileInput = document.getElementById('file-input') as HTMLInputElement;
-    const dropZone = document.getElementById('drop-zone');
-    const addMoreBtn = document.getElementById('add-more-btn');
-    const clearFilesBtn = document.getElementById('clear-files-btn');
-    const processBtn = document.getElementById('process-btn');
-    const backBtn = document.getElementById('back-to-tools');
+  const fileInput = document.getElementById('file-input') as HTMLInputElement;
+  const dropZone = document.getElementById('drop-zone');
+  const addMoreBtn = document.getElementById('add-more-btn');
+  const clearFilesBtn = document.getElementById('clear-files-btn');
+  const processBtn = document.getElementById('process-btn');
+  const backBtn = document.getElementById('back-to-tools');
 
-    if (backBtn) {
-        backBtn.addEventListener('click', () => {
-            window.location.href = import.meta.env.BASE_URL;
-        });
+  if (backBtn) {
+    backBtn.addEventListener('click', () => {
+      window.location.href = import.meta.env.BASE_URL;
+    });
+  }
+
+  const handleFileSelect = (newFiles: FileList | null) => {
+    if (!newFiles || newFiles.length === 0) return;
+    const validFiles = Array.from(newFiles).filter(
+      (file) =>
+        file.type === 'image/bmp' || file.name.toLowerCase().endsWith('.bmp')
+    );
+
+    if (validFiles.length < newFiles.length) {
+      showAlert(
+        'Invalid Files',
+        'Some files were skipped. Only BMP files are allowed.'
+      );
     }
 
-    const handleFileSelect = (newFiles: FileList | null) => {
-        if (!newFiles || newFiles.length === 0) return;
-        const validFiles = Array.from(newFiles).filter(
-            (file) => file.type === 'image/bmp' || file.name.toLowerCase().endsWith('.bmp')
-        );
-
-        if (validFiles.length < newFiles.length) {
-            showAlert('Invalid Files', 'Some files were skipped. Only BMP files are allowed.');
-        }
-
-        if (validFiles.length > 0) {
-            files = [...files, ...validFiles];
-            updateUI();
-        }
-    };
-
-    if (fileInput && dropZone) {
-        fileInput.addEventListener('change', (e) => {
-            handleFileSelect((e.target as HTMLInputElement).files);
-        });
-
-        dropZone.addEventListener('dragover', (e) => {
-            e.preventDefault();
-            dropZone.classList.add('bg-gray-700');
-        });
-
-        dropZone.addEventListener('dragleave', (e) => {
-            e.preventDefault();
-            dropZone.classList.remove('bg-gray-700');
-        });
-
-        dropZone.addEventListener('drop', (e) => {
-            e.preventDefault();
-            dropZone.classList.remove('bg-gray-700');
-            handleFileSelect(e.dataTransfer?.files ?? null);
-        });
-
-        fileInput.addEventListener('click', () => {
-            fileInput.value = '';
-        });
+    if (validFiles.length > 0) {
+      files = [...files, ...validFiles];
+      updateUI();
     }
+  };
 
-    if (addMoreBtn) {
-        addMoreBtn.addEventListener('click', () => {
-            fileInput?.click();
-        });
-    }
+  if (fileInput && dropZone) {
+    fileInput.addEventListener('change', (e) => {
+      handleFileSelect((e.target as HTMLInputElement).files);
+    });
 
-    if (clearFilesBtn) {
-        clearFilesBtn.addEventListener('click', () => {
-            resetState();
-        });
-    }
+    dropZone.addEventListener('dragover', (e) => {
+      e.preventDefault();
+      dropZone.classList.add('bg-gray-700');
+    });
 
-    if (processBtn) {
-        processBtn.addEventListener('click', convert);
-    }
+    dropZone.addEventListener('dragleave', (e) => {
+      e.preventDefault();
+      dropZone.classList.remove('bg-gray-700');
+    });
+
+    dropZone.addEventListener('drop', (e) => {
+      e.preventDefault();
+      dropZone.classList.remove('bg-gray-700');
+      handleFileSelect(e.dataTransfer?.files ?? null);
+    });
+
+    fileInput.addEventListener('click', () => {
+      fileInput.value = '';
+    });
+  }
+
+  if (addMoreBtn) {
+    addMoreBtn.addEventListener('click', () => {
+      fileInput?.click();
+    });
+  }
+
+  if (clearFilesBtn) {
+    clearFilesBtn.addEventListener('click', () => {
+      resetState();
+    });
+  }
+
+  if (processBtn) {
+    processBtn.addEventListener('click', convert);
+  }
 });

--- a/src/js/logic/heic-to-pdf-page.ts
+++ b/src/js/logic/heic-to-pdf-page.ts
@@ -1,179 +1,170 @@
 import { showLoader, hideLoader, showAlert } from '../ui.js';
-import { downloadFile, formatBytes } from '../utils/helpers.js';
-import { createIcons, icons } from 'lucide';
+import { downloadFile } from '../utils/helpers.js';
+import {
+  renderReorderableFileList,
+  destroyReorderableFileList,
+} from '../utils/reorderable-file-list.js';
 import heic2any from 'heic2any';
 import { PDFDocument as PDFLibDocument } from 'pdf-lib';
 
 let files: File[] = [];
 
 const updateUI = () => {
-    const fileDisplayArea = document.getElementById('file-display-area');
-    const fileControls = document.getElementById('file-controls');
-    const processBtn = document.getElementById('process-btn');
+  const fileDisplayArea = document.getElementById('file-display-area');
+  const fileControls = document.getElementById('file-controls');
+  const processBtn = document.getElementById('process-btn');
 
-    if (!fileDisplayArea || !fileControls || !processBtn) return;
+  if (!fileDisplayArea || !fileControls || !processBtn) return;
 
-    fileDisplayArea.innerHTML = '';
+  fileDisplayArea.innerHTML = '';
 
-    if (files.length > 0) {
-        fileControls.classList.remove('hidden');
-        processBtn.classList.remove('hidden');
+  if (files.length > 0) {
+    fileControls.classList.remove('hidden');
+    processBtn.classList.remove('hidden');
 
-        files.forEach((file, index) => {
-            const fileDiv = document.createElement('div');
-            fileDiv.className = 'flex items-center justify-between bg-gray-700 p-3 rounded-lg text-sm';
-
-            const infoContainer = document.createElement('div');
-            infoContainer.className = 'flex items-center gap-2 overflow-hidden';
-
-            const nameSpan = document.createElement('span');
-            nameSpan.className = 'truncate font-medium text-gray-200';
-            nameSpan.textContent = file.name;
-
-            const sizeSpan = document.createElement('span');
-            sizeSpan.className = 'flex-shrink-0 text-gray-400 text-xs';
-            sizeSpan.textContent = `(${formatBytes(file.size)})`;
-
-            infoContainer.append(nameSpan, sizeSpan);
-
-            const removeBtn = document.createElement('button');
-            removeBtn.className = 'ml-4 text-red-400 hover:text-red-300 flex-shrink-0';
-            removeBtn.innerHTML = '<i data-lucide="trash-2" class="w-4 h-4"></i>';
-            removeBtn.onclick = () => {
-                files = files.filter((_, i) => i !== index);
-                updateUI();
-            };
-
-            fileDiv.append(infoContainer, removeBtn);
-            fileDisplayArea.appendChild(fileDiv);
-        });
-        createIcons({ icons });
-    } else {
-        fileControls.classList.add('hidden');
-        processBtn.classList.add('hidden');
-    }
+    renderReorderableFileList({
+      container: fileDisplayArea,
+      files,
+      onReorder: (reordered) => {
+        files = reordered;
+      },
+      onRemove: (index) => {
+        files = files.filter((_, i) => i !== index);
+        updateUI();
+      },
+    });
+  } else {
+    destroyReorderableFileList(fileDisplayArea);
+    fileControls.classList.add('hidden');
+    processBtn.classList.add('hidden');
+  }
 };
 
 const resetState = () => {
-    files = [];
-    updateUI();
+  files = [];
+  updateUI();
 };
 
 async function convert() {
-    if (files.length === 0) {
-        showAlert('No Files', 'Please select at least one HEIC file.');
-        return;
+  if (files.length === 0) {
+    showAlert('No Files', 'Please select at least one HEIC file.');
+    return;
+  }
+  showLoader('Converting HEIC to PDF...');
+  try {
+    const pdfDoc = await PDFLibDocument.create();
+    for (const file of files) {
+      const conversionResult = await heic2any({
+        blob: file,
+        toType: 'image/png',
+        quality: 0.92,
+      });
+      const pngBlob = Array.isArray(conversionResult)
+        ? conversionResult[0]
+        : conversionResult;
+      const pngBytes = await pngBlob.arrayBuffer();
+      const pngImage = await pdfDoc.embedPng(pngBytes);
+      const page = pdfDoc.addPage([pngImage.width, pngImage.height]);
+      page.drawImage(pngImage, {
+        x: 0,
+        y: 0,
+        width: pngImage.width,
+        height: pngImage.height,
+      });
     }
-    showLoader('Converting HEIC to PDF...');
-    try {
-        const pdfDoc = await PDFLibDocument.create();
-        for (const file of files) {
-            const conversionResult = await heic2any({
-                blob: file,
-                toType: 'image/png',
-                quality: 0.92,
-            });
-            const pngBlob = Array.isArray(conversionResult)
-                ? conversionResult[0]
-                : conversionResult;
-            const pngBytes = await pngBlob.arrayBuffer();
-            const pngImage = await pdfDoc.embedPng(pngBytes);
-            const page = pdfDoc.addPage([pngImage.width, pngImage.height]);
-            page.drawImage(pngImage, {
-                x: 0,
-                y: 0,
-                width: pngImage.width,
-                height: pngImage.height,
-            });
-        }
-        const pdfBytes = await pdfDoc.save();
-        downloadFile(
-            new Blob([new Uint8Array(pdfBytes)], { type: 'application/pdf' }),
-            'from_heic.pdf'
-        );
-        showAlert('Success', 'PDF created successfully!', 'success', () => {
-            resetState();
-        });
-    } catch (e) {
-        console.error(e);
-        showAlert(
-            'Error',
-            'Failed to convert HEIC to PDF. One of the files may be invalid.'
-        );
-    } finally {
-        hideLoader();
-    }
+    const pdfBytes = await pdfDoc.save();
+    downloadFile(
+      new Blob([new Uint8Array(pdfBytes)], { type: 'application/pdf' }),
+      'from_heic.pdf'
+    );
+    showAlert('Success', 'PDF created successfully!', 'success', () => {
+      resetState();
+    });
+  } catch (e) {
+    console.error(e);
+    showAlert(
+      'Error',
+      'Failed to convert HEIC to PDF. One of the files may be invalid.'
+    );
+  } finally {
+    hideLoader();
+  }
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    const fileInput = document.getElementById('file-input') as HTMLInputElement;
-    const dropZone = document.getElementById('drop-zone');
-    const addMoreBtn = document.getElementById('add-more-btn');
-    const clearFilesBtn = document.getElementById('clear-files-btn');
-    const processBtn = document.getElementById('process-btn');
-    const backBtn = document.getElementById('back-to-tools');
+  const fileInput = document.getElementById('file-input') as HTMLInputElement;
+  const dropZone = document.getElementById('drop-zone');
+  const addMoreBtn = document.getElementById('add-more-btn');
+  const clearFilesBtn = document.getElementById('clear-files-btn');
+  const processBtn = document.getElementById('process-btn');
+  const backBtn = document.getElementById('back-to-tools');
 
-    if (backBtn) {
-        backBtn.addEventListener('click', () => {
-            window.location.href = import.meta.env.BASE_URL;
-        });
+  if (backBtn) {
+    backBtn.addEventListener('click', () => {
+      window.location.href = import.meta.env.BASE_URL;
+    });
+  }
+
+  const handleFileSelect = (newFiles: FileList | null) => {
+    if (!newFiles || newFiles.length === 0) return;
+    const validFiles = Array.from(newFiles).filter(
+      (file) =>
+        file.name.toLowerCase().endsWith('.heic') ||
+        file.name.toLowerCase().endsWith('.heif')
+    );
+
+    if (validFiles.length < newFiles.length) {
+      showAlert(
+        'Invalid Files',
+        'Some files were skipped. Only HEIC/HEIF files are allowed.'
+      );
     }
 
-    const handleFileSelect = (newFiles: FileList | null) => {
-        if (!newFiles || newFiles.length === 0) return;
-        const validFiles = Array.from(newFiles).filter(
-            (file) => file.name.toLowerCase().endsWith('.heic') || file.name.toLowerCase().endsWith('.heif')
-        );
-
-        if (validFiles.length < newFiles.length) {
-            showAlert('Invalid Files', 'Some files were skipped. Only HEIC/HEIF files are allowed.');
-        }
-
-        if (validFiles.length > 0) {
-            files = [...files, ...validFiles];
-            updateUI();
-        }
-    };
-
-    if (fileInput && dropZone) {
-        fileInput.addEventListener('change', (e) => {
-            handleFileSelect((e.target as HTMLInputElement).files);
-        });
-
-        dropZone.addEventListener('dragover', (e) => {
-            e.preventDefault();
-            dropZone.classList.add('bg-gray-700');
-        });
-
-        dropZone.addEventListener('dragleave', (e) => {
-            e.preventDefault();
-            dropZone.classList.remove('bg-gray-700');
-        });
-
-        dropZone.addEventListener('drop', (e) => {
-            e.preventDefault();
-            dropZone.classList.remove('bg-gray-700');
-            handleFileSelect(e.dataTransfer?.files ?? null);
-        });
-
-        fileInput.addEventListener('click', () => {
-            fileInput.value = '';
-        });
+    if (validFiles.length > 0) {
+      files = [...files, ...validFiles];
+      updateUI();
     }
+  };
 
-    if (addMoreBtn) {
-        addMoreBtn.addEventListener('click', () => {
-            fileInput?.click();
-        });
-    }
+  if (fileInput && dropZone) {
+    fileInput.addEventListener('change', (e) => {
+      handleFileSelect((e.target as HTMLInputElement).files);
+    });
 
-    if (clearFilesBtn) {
-        clearFilesBtn.addEventListener('click', () => {
-            resetState();
-        });
-    }
+    dropZone.addEventListener('dragover', (e) => {
+      e.preventDefault();
+      dropZone.classList.add('bg-gray-700');
+    });
 
-    if (processBtn) {
-        processBtn.addEventListener('click', convert);
-    }
+    dropZone.addEventListener('dragleave', (e) => {
+      e.preventDefault();
+      dropZone.classList.remove('bg-gray-700');
+    });
+
+    dropZone.addEventListener('drop', (e) => {
+      e.preventDefault();
+      dropZone.classList.remove('bg-gray-700');
+      handleFileSelect(e.dataTransfer?.files ?? null);
+    });
+
+    fileInput.addEventListener('click', () => {
+      fileInput.value = '';
+    });
+  }
+
+  if (addMoreBtn) {
+    addMoreBtn.addEventListener('click', () => {
+      fileInput?.click();
+    });
+  }
+
+  if (clearFilesBtn) {
+    clearFilesBtn.addEventListener('click', () => {
+      resetState();
+    });
+  }
+
+  if (processBtn) {
+    processBtn.addEventListener('click', convert);
+  }
 });

--- a/src/js/logic/image-to-pdf-page.ts
+++ b/src/js/logic/image-to-pdf-page.ts
@@ -1,6 +1,10 @@
 import { createIcons, icons } from 'lucide';
 import { showAlert, showLoader, hideLoader } from '@/js/ui.js';
-import { downloadFile, formatBytes } from '@/js/utils/helpers.js';
+import { downloadFile } from '@/js/utils/helpers.js';
+import {
+  renderReorderableFileList,
+  destroyReorderableFileList,
+} from '@/js/utils/reorderable-file-list.js';
 import { loadPyMuPDF } from '@/js/utils/pymupdf-loader.js';
 import type { PyMuPDFInstance } from '@/types';
 import {
@@ -129,38 +133,19 @@ function updateUI() {
     fileControls.classList.remove('hidden');
     optionsDiv.classList.remove('hidden');
 
-    files.forEach((file, index) => {
-      const fileDiv = document.createElement('div');
-      fileDiv.className =
-        'flex items-center justify-between bg-gray-700 p-3 rounded-lg text-sm';
-
-      const infoContainer = document.createElement('div');
-      infoContainer.className = 'flex items-center gap-2 overflow-hidden';
-
-      const nameSpan = document.createElement('span');
-      nameSpan.className = 'truncate font-medium text-gray-200';
-      nameSpan.textContent = file.name;
-
-      const sizeSpan = document.createElement('span');
-      sizeSpan.className = 'flex-shrink-0 text-gray-400 text-xs';
-      sizeSpan.textContent = `(${formatBytes(file.size)})`;
-
-      infoContainer.append(nameSpan, sizeSpan);
-
-      const removeBtn = document.createElement('button');
-      removeBtn.className =
-        'ml-4 text-red-400 hover:text-red-300 flex-shrink-0';
-      removeBtn.innerHTML = '<i data-lucide="trash-2" class="w-4 h-4"></i>';
-      removeBtn.onclick = () => {
+    renderReorderableFileList({
+      container: fileDisplayArea,
+      files,
+      onReorder: (reordered) => {
+        files = reordered;
+      },
+      onRemove: (index) => {
         files = files.filter((_, i) => i !== index);
         updateUI();
-      };
-
-      fileDiv.append(infoContainer, removeBtn);
-      fileDisplayArea.appendChild(fileDiv);
+      },
     });
-    createIcons({ icons });
   } else {
+    destroyReorderableFileList(fileDisplayArea);
     fileControls.classList.add('hidden');
     optionsDiv.classList.add('hidden');
   }

--- a/src/js/logic/jpg-to-pdf-page.ts
+++ b/src/js/logic/jpg-to-pdf-page.ts
@@ -1,6 +1,10 @@
 import { createIcons, icons } from 'lucide';
 import { showAlert, showLoader, hideLoader } from '../ui.js';
-import { downloadFile, formatBytes } from '../utils/helpers.js';
+import { downloadFile } from '../utils/helpers.js';
+import {
+  renderReorderableFileList,
+  destroyReorderableFileList,
+} from '../utils/reorderable-file-list.js';
 import { loadPyMuPDF } from '../utils/pymupdf-loader.js';
 import type { PyMuPDFInstance } from '@/types';
 import {
@@ -132,38 +136,19 @@ function updateUI() {
     fileControls.classList.remove('hidden');
     optionsDiv.classList.remove('hidden');
 
-    files.forEach((file, index) => {
-      const fileDiv = document.createElement('div');
-      fileDiv.className =
-        'flex items-center justify-between bg-gray-700 p-3 rounded-lg text-sm';
-
-      const infoContainer = document.createElement('div');
-      infoContainer.className = 'flex items-center gap-2 overflow-hidden';
-
-      const nameSpan = document.createElement('span');
-      nameSpan.className = 'truncate font-medium text-gray-200';
-      nameSpan.textContent = file.name;
-
-      const sizeSpan = document.createElement('span');
-      sizeSpan.className = 'flex-shrink-0 text-gray-400 text-xs';
-      sizeSpan.textContent = `(${formatBytes(file.size)})`;
-
-      infoContainer.append(nameSpan, sizeSpan);
-
-      const removeBtn = document.createElement('button');
-      removeBtn.className =
-        'ml-4 text-red-400 hover:text-red-300 flex-shrink-0';
-      removeBtn.innerHTML = '<i data-lucide="trash-2" class="w-4 h-4"></i>';
-      removeBtn.onclick = () => {
+    renderReorderableFileList({
+      container: fileDisplayArea,
+      files,
+      onReorder: (reordered) => {
+        files = reordered;
+      },
+      onRemove: (index) => {
         files = files.filter((_, i) => i !== index);
         updateUI();
-      };
-
-      fileDiv.append(infoContainer, removeBtn);
-      fileDisplayArea.appendChild(fileDiv);
+      },
     });
-    createIcons({ icons });
   } else {
+    destroyReorderableFileList(fileDisplayArea);
     fileControls.classList.add('hidden');
     optionsDiv.classList.add('hidden');
   }

--- a/src/js/logic/png-to-pdf-page.ts
+++ b/src/js/logic/png-to-pdf-page.ts
@@ -1,10 +1,10 @@
 import { createIcons, icons } from 'lucide';
 import { showAlert, showLoader, hideLoader } from '../ui.js';
+import { downloadFile, readFileAsArrayBuffer } from '../utils/helpers.js';
 import {
-  downloadFile,
-  readFileAsArrayBuffer,
-  formatBytes,
-} from '../utils/helpers.js';
+  renderReorderableFileList,
+  destroyReorderableFileList,
+} from '../utils/reorderable-file-list.js';
 import { PDFDocument as PDFLibDocument } from 'pdf-lib';
 import {
   getSelectedQuality,
@@ -123,38 +123,19 @@ function updateUI() {
     fileControls.classList.remove('hidden');
     optionsDiv.classList.remove('hidden');
 
-    files.forEach((file, index) => {
-      const fileDiv = document.createElement('div');
-      fileDiv.className =
-        'flex items-center justify-between bg-gray-700 p-3 rounded-lg text-sm';
-
-      const infoContainer = document.createElement('div');
-      infoContainer.className = 'flex items-center gap-2 overflow-hidden';
-
-      const nameSpan = document.createElement('span');
-      nameSpan.className = 'truncate font-medium text-gray-200';
-      nameSpan.textContent = file.name;
-
-      const sizeSpan = document.createElement('span');
-      sizeSpan.className = 'flex-shrink-0 text-gray-400 text-xs';
-      sizeSpan.textContent = `(${formatBytes(file.size)})`;
-
-      infoContainer.append(nameSpan, sizeSpan);
-
-      const removeBtn = document.createElement('button');
-      removeBtn.className =
-        'ml-4 text-red-400 hover:text-red-300 flex-shrink-0';
-      removeBtn.innerHTML = '<i data-lucide="trash-2" class="w-4 h-4"></i>';
-      removeBtn.onclick = () => {
+    renderReorderableFileList({
+      container: fileDisplayArea,
+      files,
+      onReorder: (reordered) => {
+        files = reordered;
+      },
+      onRemove: (index) => {
         files = files.filter((_, i) => i !== index);
         updateUI();
-      };
-
-      fileDiv.append(infoContainer, removeBtn);
-      fileDisplayArea.appendChild(fileDiv);
+      },
     });
-    createIcons({ icons });
   } else {
+    destroyReorderableFileList(fileDisplayArea);
     fileControls.classList.add('hidden');
     optionsDiv.classList.add('hidden');
   }

--- a/src/js/logic/psd-to-pdf-page.ts
+++ b/src/js/logic/psd-to-pdf-page.ts
@@ -1,7 +1,10 @@
 import { showLoader, hideLoader, showAlert } from '../ui.js';
-import { downloadFile, formatBytes } from '../utils/helpers.js';
+import { downloadFile } from '../utils/helpers.js';
+import {
+  renderReorderableFileList,
+  destroyReorderableFileList,
+} from '../utils/reorderable-file-list.js';
 import { state } from '../state.js';
-import { createIcons, icons } from 'lucide';
 import { loadPyMuPDF } from '../utils/pymupdf-loader.js';
 import type { PyMuPDFInstance } from '@/types';
 
@@ -36,36 +39,21 @@ document.addEventListener('DOMContentLoaded', () => {
   const updateUI = async () => {
     if (!fileDisplayArea || !processBtn || !fileControls) return;
     if (state.files.length > 0) {
-      fileDisplayArea.innerHTML = '';
-      for (let index = 0; index < state.files.length; index++) {
-        const file = state.files[index];
-        const fileDiv = document.createElement('div');
-        fileDiv.className =
-          'flex items-center justify-between bg-gray-700 p-3 rounded-lg text-sm';
-        const infoContainer = document.createElement('div');
-        infoContainer.className = 'flex flex-col overflow-hidden';
-        const nameSpan = document.createElement('div');
-        nameSpan.className = 'truncate font-medium text-gray-200 text-sm mb-1';
-        nameSpan.textContent = file.name;
-        const metaSpan = document.createElement('div');
-        metaSpan.className = 'text-xs text-gray-400';
-        metaSpan.textContent = formatBytes(file.size);
-        infoContainer.append(nameSpan, metaSpan);
-        const removeBtn = document.createElement('button');
-        removeBtn.className =
-          'ml-4 text-red-400 hover:text-red-300 flex-shrink-0';
-        removeBtn.innerHTML = '<i data-lucide="trash-2" class="w-4 h-4"></i>';
-        removeBtn.onclick = () => {
+      renderReorderableFileList({
+        container: fileDisplayArea,
+        files: state.files as File[],
+        onReorder: (reordered) => {
+          state.files = reordered;
+        },
+        onRemove: (index) => {
           state.files = state.files.filter((_, i) => i !== index);
           updateUI();
-        };
-        fileDiv.append(infoContainer, removeBtn);
-        fileDisplayArea.appendChild(fileDiv);
-      }
-      createIcons({ icons });
+        },
+      });
       fileControls.classList.remove('hidden');
       processBtn.classList.remove('hidden');
     } else {
+      destroyReorderableFileList(fileDisplayArea);
       fileDisplayArea.innerHTML = '';
       fileControls.classList.add('hidden');
       processBtn.classList.add('hidden');

--- a/src/js/logic/svg-to-pdf-page.ts
+++ b/src/js/logic/svg-to-pdf-page.ts
@@ -1,6 +1,10 @@
 import { createIcons, icons } from 'lucide';
 import { showAlert, showLoader, hideLoader } from '../ui.js';
-import { downloadFile, formatBytes } from '../utils/helpers.js';
+import { downloadFile } from '../utils/helpers.js';
+import {
+  renderReorderableFileList,
+  destroyReorderableFileList,
+} from '../utils/reorderable-file-list.js';
 import { PDFDocument as PDFLibDocument } from 'pdf-lib';
 import {
   getSelectedQuality,
@@ -119,38 +123,19 @@ function updateUI() {
     fileControls.classList.remove('hidden');
     optionsDiv.classList.remove('hidden');
 
-    files.forEach((file, index) => {
-      const fileDiv = document.createElement('div');
-      fileDiv.className =
-        'flex items-center justify-between bg-gray-700 p-3 rounded-lg text-sm';
-
-      const infoContainer = document.createElement('div');
-      infoContainer.className = 'flex items-center gap-2 overflow-hidden';
-
-      const nameSpan = document.createElement('span');
-      nameSpan.className = 'truncate font-medium text-gray-200';
-      nameSpan.textContent = file.name;
-
-      const sizeSpan = document.createElement('span');
-      sizeSpan.className = 'flex-shrink-0 text-gray-400 text-xs';
-      sizeSpan.textContent = `(${formatBytes(file.size)})`;
-
-      infoContainer.append(nameSpan, sizeSpan);
-
-      const removeBtn = document.createElement('button');
-      removeBtn.className =
-        'ml-4 text-red-400 hover:text-red-300 flex-shrink-0';
-      removeBtn.innerHTML = '<i data-lucide="trash-2" class="w-4 h-4"></i>';
-      removeBtn.onclick = () => {
+    renderReorderableFileList({
+      container: fileDisplayArea,
+      files,
+      onReorder: (reordered) => {
+        files = reordered;
+      },
+      onRemove: (index) => {
         files = files.filter((_, i) => i !== index);
         updateUI();
-      };
-
-      fileDiv.append(infoContainer, removeBtn);
-      fileDisplayArea.appendChild(fileDiv);
+      },
     });
-    createIcons({ icons });
   } else {
+    destroyReorderableFileList(fileDisplayArea);
     fileControls.classList.add('hidden');
     optionsDiv.classList.add('hidden');
   }

--- a/src/js/logic/tiff-to-pdf-page.ts
+++ b/src/js/logic/tiff-to-pdf-page.ts
@@ -1,10 +1,9 @@
 import { showLoader, hideLoader, showAlert } from '../ui.js';
+import { downloadFile, readFileAsArrayBuffer } from '../utils/helpers.js';
 import {
-  downloadFile,
-  formatBytes,
-  readFileAsArrayBuffer,
-} from '../utils/helpers.js';
-import { createIcons, icons } from 'lucide';
+  renderReorderableFileList,
+  destroyReorderableFileList,
+} from '../utils/reorderable-file-list.js';
 import { PDFDocument as PDFLibDocument } from 'pdf-lib';
 import { decode } from 'tiff';
 import { tiffIfdToRgba } from '../utils/tiff-utils.js';
@@ -27,38 +26,19 @@ const updateUI = () => {
     processBtn.classList.remove('hidden');
     optionsPanel?.classList.remove('hidden');
 
-    files.forEach((file, index) => {
-      const fileDiv = document.createElement('div');
-      fileDiv.className =
-        'flex items-center justify-between bg-gray-700 p-3 rounded-lg text-sm';
-
-      const infoContainer = document.createElement('div');
-      infoContainer.className = 'flex items-center gap-2 overflow-hidden';
-
-      const nameSpan = document.createElement('span');
-      nameSpan.className = 'truncate font-medium text-gray-200';
-      nameSpan.textContent = file.name;
-
-      const sizeSpan = document.createElement('span');
-      sizeSpan.className = 'flex-shrink-0 text-gray-400 text-xs';
-      sizeSpan.textContent = `(${formatBytes(file.size)})`;
-
-      infoContainer.append(nameSpan, sizeSpan);
-
-      const removeBtn = document.createElement('button');
-      removeBtn.className =
-        'ml-4 text-red-400 hover:text-red-300 flex-shrink-0';
-      removeBtn.innerHTML = '<i data-lucide="trash-2" class="w-4 h-4"></i>';
-      removeBtn.onclick = () => {
+    renderReorderableFileList({
+      container: fileDisplayArea,
+      files,
+      onReorder: (reordered) => {
+        files = reordered;
+      },
+      onRemove: (index) => {
         files = files.filter((_, i) => i !== index);
         updateUI();
-      };
-
-      fileDiv.append(infoContainer, removeBtn);
-      fileDisplayArea.appendChild(fileDiv);
+      },
     });
-    createIcons({ icons });
   } else {
+    destroyReorderableFileList(fileDisplayArea);
     fileControls.classList.add('hidden');
     processBtn.classList.add('hidden');
     optionsPanel?.classList.add('hidden');

--- a/src/js/logic/txt-to-pdf-page.ts
+++ b/src/js/logic/txt-to-pdf-page.ts
@@ -1,5 +1,9 @@
 import { showLoader, hideLoader, showAlert } from '../ui.js';
-import { downloadFile, formatBytes } from '../utils/helpers.js';
+import { downloadFile } from '../utils/helpers.js';
+import {
+  renderReorderableFileList,
+  destroyReorderableFileList,
+} from '../utils/reorderable-file-list.js';
 import { createIcons, icons } from 'lucide';
 import { loadPyMuPDF } from '../utils/pymupdf-loader.js';
 
@@ -27,32 +31,19 @@ const updateUI = () => {
     dropZone.classList.add('hidden');
     fileControls.classList.remove('hidden');
 
-    files.forEach((file, index) => {
-      const fileDiv = document.createElement('div');
-      fileDiv.className =
-        'flex items-center justify-between bg-gray-700 p-3 rounded-lg text-sm';
-
-      const infoSpan = document.createElement('span');
-      infoSpan.className = 'truncate font-medium text-gray-200';
-      infoSpan.textContent = file.name;
-
-      const sizeSpan = document.createElement('span');
-      sizeSpan.className = 'text-gray-400 text-xs ml-2';
-      sizeSpan.textContent = `(${formatBytes(file.size)})`;
-
-      const removeBtn = document.createElement('button');
-      removeBtn.className = 'ml-4 text-red-400 hover:text-red-300';
-      removeBtn.innerHTML = '<i data-lucide="trash-2" class="w-4 h-4"></i>';
-      removeBtn.onclick = () => {
+    renderReorderableFileList({
+      container: fileDisplayArea,
+      files,
+      onReorder: (reordered) => {
+        files = reordered;
+      },
+      onRemove: (index) => {
         files = files.filter((_, i) => i !== index);
         updateUI();
-      };
-
-      fileDiv.append(infoSpan, sizeSpan, removeBtn);
-      fileDisplayArea.appendChild(fileDiv);
+      },
     });
-    createIcons({ icons });
   } else {
+    destroyReorderableFileList(fileDisplayArea);
     dropZone.classList.remove('hidden');
     fileControls.classList.add('hidden');
   }

--- a/src/js/logic/webp-to-pdf-page.ts
+++ b/src/js/logic/webp-to-pdf-page.ts
@@ -1,10 +1,10 @@
 import { createIcons, icons } from 'lucide';
 import { showAlert, showLoader, hideLoader } from '../ui.js';
+import { downloadFile, readFileAsArrayBuffer } from '../utils/helpers.js';
 import {
-  downloadFile,
-  readFileAsArrayBuffer,
-  formatBytes,
-} from '../utils/helpers.js';
+  renderReorderableFileList,
+  destroyReorderableFileList,
+} from '../utils/reorderable-file-list.js';
 import { PDFDocument as PDFLibDocument } from 'pdf-lib';
 import {
   getSelectedQuality,
@@ -123,38 +123,19 @@ function updateUI() {
     fileControls.classList.remove('hidden');
     optionsDiv.classList.remove('hidden');
 
-    files.forEach((file, index) => {
-      const fileDiv = document.createElement('div');
-      fileDiv.className =
-        'flex items-center justify-between bg-gray-700 p-3 rounded-lg text-sm';
-
-      const infoContainer = document.createElement('div');
-      infoContainer.className = 'flex items-center gap-2 overflow-hidden';
-
-      const nameSpan = document.createElement('span');
-      nameSpan.className = 'truncate font-medium text-gray-200';
-      nameSpan.textContent = file.name;
-
-      const sizeSpan = document.createElement('span');
-      sizeSpan.className = 'flex-shrink-0 text-gray-400 text-xs';
-      sizeSpan.textContent = `(${formatBytes(file.size)})`;
-
-      infoContainer.append(nameSpan, sizeSpan);
-
-      const removeBtn = document.createElement('button');
-      removeBtn.className =
-        'ml-4 text-red-400 hover:text-red-300 flex-shrink-0';
-      removeBtn.innerHTML = '<i data-lucide="trash-2" class="w-4 h-4"></i>';
-      removeBtn.onclick = () => {
+    renderReorderableFileList({
+      container: fileDisplayArea,
+      files,
+      onReorder: (reordered) => {
+        files = reordered;
+      },
+      onRemove: (index) => {
         files = files.filter((_, i) => i !== index);
         updateUI();
-      };
-
-      fileDiv.append(infoContainer, removeBtn);
-      fileDisplayArea.appendChild(fileDiv);
+      },
     });
-    createIcons({ icons });
   } else {
+    destroyReorderableFileList(fileDisplayArea);
     fileControls.classList.add('hidden');
     optionsDiv.classList.add('hidden');
   }

--- a/src/js/utils/reorderable-file-list.ts
+++ b/src/js/utils/reorderable-file-list.ts
@@ -38,13 +38,18 @@ export function renderReorderableFileList({
   destroyReorderableFileList(container);
   container.textContent = '';
 
-  files.forEach((file, index) => {
+  // The rows are re-indexed in place after every drag and the caller only
+  // rebinds its own array, so the order has to be tracked here: reading the
+  // render-time `files` again would map fresh indices onto a stale array.
+  let currentFiles = [...files];
+
+  currentFiles.forEach((file, index) => {
     container.appendChild(createFileRow(file, index, onRemove));
   });
 
   createIcons({ icons });
 
-  if (files.length === 0) return;
+  if (currentFiles.length === 0) return;
 
   const instance = Sortable.create(container, {
     handle: '.drag-handle',
@@ -59,7 +64,8 @@ export function renderReorderableFileList({
       evt.item.style.opacity = '1';
       // Sync in place rather than re-rendering: destroying the Sortable
       // instance from inside its own onEnd handler is not safe.
-      onReorder(syncOrderWithDom(container, files));
+      currentFiles = syncOrderWithDom(container, currentFiles);
+      onReorder(currentFiles);
     },
   });
 

--- a/src/js/utils/reorderable-file-list.ts
+++ b/src/js/utils/reorderable-file-list.ts
@@ -1,0 +1,144 @@
+import { createIcons, icons } from 'lucide';
+import Sortable from 'sortablejs';
+import { formatBytes } from './helpers.js';
+
+/**
+ * Shared drag-to-reorder file list, used by the tools that combine several
+ * uploads into a single ordered document (images-to-PDF, text-to-PDF, ...).
+ * The visual order of the rows is the page order of the generated PDF, so the
+ * user needs to be able to rearrange them.
+ */
+export interface ReorderableFileListOptions {
+  /** Element that holds the file rows (usually `#file-display-area`). */
+  container: HTMLElement;
+  /** Files to render, in output order. */
+  files: File[];
+  /**
+   * Called after a drag with the files in their new order. The rows have
+   * already been re-labelled in place, so the caller only needs to store the
+   * new array — re-rendering is not required.
+   */
+  onReorder: (files: File[]) => void;
+  /** Called with the index of the file whose remove button was clicked. */
+  onRemove: (index: number) => void;
+}
+
+const sortableInstances = new WeakMap<HTMLElement, Sortable>();
+
+/**
+ * Renders `files` into `container` as a drag-sortable list, replacing whatever
+ * was there before. Safe to call on every UI update.
+ */
+export function renderReorderableFileList({
+  container,
+  files,
+  onReorder,
+  onRemove,
+}: ReorderableFileListOptions): void {
+  destroyReorderableFileList(container);
+  container.textContent = '';
+
+  files.forEach((file, index) => {
+    container.appendChild(createFileRow(file, index, onRemove));
+  });
+
+  createIcons({ icons });
+
+  if (files.length === 0) return;
+
+  const instance = Sortable.create(container, {
+    handle: '.drag-handle',
+    animation: 150,
+    ghostClass: 'sortable-ghost',
+    chosenClass: 'sortable-chosen',
+    dragClass: 'sortable-drag',
+    onStart: function (evt: Sortable.SortableEvent) {
+      evt.item.style.opacity = '0.5';
+    },
+    onEnd: function (evt: Sortable.SortableEvent) {
+      evt.item.style.opacity = '1';
+      // Sync in place rather than re-rendering: destroying the Sortable
+      // instance from inside its own onEnd handler is not safe.
+      onReorder(syncOrderWithDom(container, files));
+    },
+  });
+
+  sortableInstances.set(container, instance);
+}
+
+/** Tears down the drag behaviour for a container (e.g. when the list empties). */
+export function destroyReorderableFileList(container: HTMLElement): void {
+  const instance = sortableInstances.get(container);
+  if (instance) {
+    instance.destroy();
+    sortableInstances.delete(container);
+  }
+}
+
+function createFileRow(
+  file: File,
+  index: number,
+  onRemove: (index: number) => void
+): HTMLElement {
+  const fileDiv = document.createElement('div');
+  fileDiv.className =
+    'flex items-center justify-between bg-gray-700 p-3 rounded-lg text-sm border border-transparent hover:border-indigo-500 transition-colors';
+  fileDiv.dataset.fileIndex = String(index);
+
+  const infoContainer = document.createElement('div');
+  infoContainer.className =
+    'flex items-center gap-2 overflow-hidden flex-1 mr-2';
+
+  const dragHandle = document.createElement('div');
+  dragHandle.className =
+    'drag-handle cursor-move text-gray-400 hover:text-white p-1 rounded flex-shrink-0 transition-colors';
+  dragHandle.title = 'Drag to reorder';
+  dragHandle.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="9" cy="5" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="9" cy="12" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="19" r="1"/></svg>`; // Safe: static content
+
+  const orderSpan = document.createElement('span');
+  orderSpan.className = 'file-order flex-shrink-0 text-gray-400 text-xs w-6';
+  orderSpan.textContent = `${index + 1}.`;
+
+  const nameSpan = document.createElement('span');
+  nameSpan.className = 'truncate font-medium text-gray-200';
+  nameSpan.title = file.name;
+  nameSpan.textContent = file.name;
+
+  const sizeSpan = document.createElement('span');
+  sizeSpan.className = 'flex-shrink-0 text-gray-400 text-xs';
+  sizeSpan.textContent = `(${formatBytes(file.size)})`;
+
+  infoContainer.append(dragHandle, orderSpan, nameSpan, sizeSpan);
+
+  const removeBtn = document.createElement('button');
+  removeBtn.className = 'ml-4 text-red-400 hover:text-red-300 flex-shrink-0';
+  removeBtn.innerHTML = '<i data-lucide="trash-2" class="w-4 h-4"></i>'; // Safe: static content
+  removeBtn.title = 'Remove file';
+  removeBtn.onclick = () => {
+    // Read the position from the DOM so the handler stays correct after a drag.
+    onRemove(Number(fileDiv.dataset.fileIndex));
+  };
+
+  fileDiv.append(infoContainer, removeBtn);
+  return fileDiv;
+}
+
+/**
+ * Re-orders `files` to match the current DOM order, then refreshes the position
+ * labels and index bookkeeping on the rows.
+ */
+function syncOrderWithDom(container: HTMLElement, files: File[]): File[] {
+  const rows = Array.from(
+    container.querySelectorAll<HTMLElement>('[data-file-index]')
+  );
+
+  const reordered = rows.map((row) => files[Number(row.dataset.fileIndex)]);
+
+  rows.forEach((row, index) => {
+    row.dataset.fileIndex = String(index);
+    const orderSpan = row.querySelector('.file-order');
+    if (orderSpan) orderSpan.textContent = `${index + 1}.`;
+  });
+
+  return reordered;
+}


### PR DESCRIPTION
## Problem

The tools that combine several uploads into a **single** PDF render their file list in upload order with no way to rearrange it. If the images land in the wrong order, the only fix is to clear the list and re-pick the files one at a time.

`merge-pdf` already solves exactly this with SortableJS — this brings the same interaction to the converters that need it.

Reported for `/image-to-pdf` and `/jpg-to-pdf`; the same gap exists on eight sibling routes.

## Approach

New shared component `src/js/utils/reorderable-file-list.ts`, exporting `renderReorderableFileList` / `destroyReorderableFileList`. It renders each row with a grip handle and a position number, and wires SortableJS with the same configuration and `sortable-ghost` / `sortable-chosen` / `sortable-drag` classes merge-pdf uses, so the drag feel and styling are identical (the CSS already exists in `styles.css`).

Two details worth calling out:

- **Order syncs in place, not by re-rendering.** On drop the component maps the DOM order back onto the file array and renumbers the labels directly. Re-rendering would destroy the Sortable instance from inside its own `onEnd` handler, which is not safe. Same pattern as `fileHandler.ts`.
- **Remove buttons read their index from the DOM** (`data-file-index`) instead of a closure variable, so deleting a file after a drag removes the intended one rather than a stale position.

## Scope

Adopted in the ten tools whose output order *is* the file order, each of which had its own near-identical copy of the row-rendering loop:

`image-to-pdf` · `jpg-to-pdf` · `png-to-pdf` · `webp-to-pdf` · `svg-to-pdf` · `tiff-to-pdf` · `bmp-to-pdf` · `heic-to-pdf` · `psd-to-pdf` · `txt-to-pdf`

Deliberately **not** changed: batch tools that emit one output per input or a zip (`compress-pdf-*`, `pages-to-pdf`, `csv-to-pdf`, `email-to-pdf`, `cbz-to-pdf`, `pdf-to-*`, …) — their file order is not observable in the result.

## Notes for review

- **`bmp-to-pdf` and `heic-to-pdf` show large line counts** — those two files were 4-space indented and the repo's own pre-commit prettier hook normalized them. Reviewing with `git diff -w` shows the real change is ~50 lines each, the same as the other files.
- **Two small visual normalizations**, both toward the shared layout: `psd-to-pdf` previously stacked name over size on two lines, and `txt-to-pdf` had a slightly different row structure. Both now match the other eight.

## Testing

- `tsc --noEmit` and `eslint` clean across all 11 files.
- `vitest run` shows no new failures (12 pre-existing failures in 2 files, identical on a clean tree).
- Manually exercised all ten routes in a dev server: drag-reorder updates the array and the position labels, and deleting a file after a drag removes the correct one. No console errors.

<img width="570" height="366" alt="Screenshot 2026-09-08 at 3 51 12 PM" src="https://github.com/user-attachments/assets/38ca1e36-cf0f-4ec5-9f38-51658d9efbc9" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop reordering for uploaded files across image, document, and design-file to PDF converters.
  * Added consistent file lists with ordering indicators, drag handles, and remove controls.
  * File order now stays synchronized with the conversion sequence after rearranging.
* **Changes**
  * File size information is no longer displayed in upload lists.
  * File-list interactions are now consistent across supported PDF conversion tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->