### PR TITLE
fix: default PDF timestamping to an HTTPS TSA

### DIFF
--- a/src/js/config/timestamp-tsa.ts
+++ b/src/js/config/timestamp-tsa.ts
@@ -5,11 +5,12 @@ export interface TimestampTsaPreset {
 
 // Some TSA providers only expose HTTP endpoints. RFC 3161 timestamp tokens are
 // signed at the application layer, so integrity does not depend solely on TLS.
+// The first preset is the default and must use HTTPS for unproxied HTTPS pages.
 export const TIMESTAMP_TSA_PRESETS: TimestampTsaPreset[] = [
+  { label: 'FreeTSA', url: 'https://freetsa.org/tsr' },
   { label: 'DigiCert', url: 'http://timestamp.digicert.com' },
   { label: 'Sectigo', url: 'http://timestamp.sectigo.com' },
   { label: 'SSL.com', url: 'http://ts.ssl.com' },
-  { label: 'FreeTSA', url: 'https://freetsa.org/tsr' },
   { label: 'MeSign', url: 'http://tsa.mesign.com' },
 ];
 

--- a/src/tests/digital-sign-pdf.test.ts
+++ b/src/tests/digital-sign-pdf.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { TIMESTAMP_TSA_PRESETS } from '@/js/config/timestamp-tsa';
 
-const mockSign = vi.fn();
+const { mockSign } = vi.hoisted(() => ({ mockSign: vi.fn() }));
 
 vi.mock('zgapdfsigner', () => {
   const MockPdfSigner = vi.fn(function (this: { sign: typeof mockSign }) {
@@ -12,7 +13,13 @@ vi.mock('zgapdfsigner', () => {
 });
 
 import { PdfSigner } from 'zgapdfsigner';
-import { timestampPdf } from '@/js/logic/digital-sign-pdf';
+
+function stubPageOrigin(origin: string): void {
+  vi.stubGlobal('window', {
+    location: new URL(origin),
+    fetch: vi.fn().mockRejectedValue(new Error('Unexpected network request')),
+  });
+}
 
 const SAMPLE_PDF_PATH = path.resolve(__dirname, './fixtures/sample.pdf');
 const SAMPLE_PDF_SHA256 =
@@ -30,12 +37,41 @@ async function sha256(data: Uint8Array): Promise<string> {
 
 describe('timestampPdf', () => {
   let samplePdfBytes: Uint8Array;
+  let timestampPdf: typeof import('@/js/logic/digital-sign-pdf').timestampPdf;
 
-  beforeEach(() => {
-    vi.clearAllMocks();
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    vi.resetModules();
     vi.stubEnv('VITE_CORS_PROXY_URL', '');
     vi.stubEnv('VITE_CORS_PROXY_SECRET', '');
+    stubPageOrigin('http://localhost');
+    ({ timestampPdf } = await import('@/js/logic/digital-sign-pdf'));
     samplePdfBytes = new Uint8Array(fs.readFileSync(SAMPLE_PDF_PATH));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.resetAllMocks();
+    vi.resetModules();
+  });
+
+  it('should use the unchanged HTTPS default without a proxy on an HTTPS page', async () => {
+    stubPageOrigin('https://www.bentopdf.com');
+    const fetchSpy = window.fetch;
+    const fakeSigned = new Uint8Array([1, 2, 3]);
+    mockSign.mockResolvedValueOnce(fakeSigned);
+    const defaultUrl = TIMESTAMP_TSA_PRESETS[0].url;
+
+    const result = await timestampPdf(samplePdfBytes, defaultUrl);
+
+    expect(new URL(defaultUrl).protocol).toBe('https:');
+    expect(PdfSigner).toHaveBeenCalledExactlyOnceWith({
+      signdate: { url: defaultUrl },
+    });
+    expect(mockSign).toHaveBeenCalledExactlyOnceWith(samplePdfBytes);
+    expect(result).toEqual(fakeSigned);
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it('should load the correct sample PDF', async () => {
@@ -117,6 +153,7 @@ describe('timestampPdf', () => {
   });
 
   it('should pre-proxy the TSA URL when CORS proxy is configured', async () => {
+    stubPageOrigin('https://www.bentopdf.com');
     vi.stubEnv(
       'VITE_CORS_PROXY_URL',
       'https://bentopdf-cors-proxy.bentopdf.workers.dev'
@@ -131,26 +168,19 @@ describe('timestampPdf', () => {
     const callArg = vi.mocked(PdfSigner).mock.calls[0][0] as {
       signdate: { url: string };
     };
-    expect(callArg.signdate.url).toMatch(
-      /^https:\/\/bentopdf-cors-proxy\.bentopdf\.workers\.dev\?url=/
-    );
-    expect(callArg.signdate.url).toContain(
-      encodeURIComponent('http://timestamp.digicert.com')
+    expect(callArg.signdate.url).toBe(
+      'https://bentopdf-cors-proxy.bentopdf.workers.dev?url=' +
+        encodeURIComponent('http://timestamp.digicert.com')
     );
   });
 
   it('should throw a clear error when HTTPS page targets HTTP TSA without proxy', async () => {
-    vi.stubEnv('VITE_CORS_PROXY_URL', '');
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: { protocol: 'https:', origin: 'https://www.bentopdf.com' },
-    });
-    vi.resetModules();
-    const { timestampPdf: freshTimestamp } =
-      await import('@/js/logic/digital-sign-pdf');
+    stubPageOrigin('https://www.bentopdf.com');
 
     await expect(
-      freshTimestamp(samplePdfBytes, 'http://timestamp.digicert.com')
+      timestampPdf(samplePdfBytes, 'http://timestamp.digicert.com')
     ).rejects.toThrow(/HTTPS page|VITE_CORS_PROXY_URL/);
+    expect(PdfSigner).not.toHaveBeenCalled();
+    expect(mockSign).not.toHaveBeenCalled();
   });
 });

--- a/src/tests/timestamp-node.test.ts
+++ b/src/tests/timestamp-node.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { TIMESTAMP_TSA_PRESETS } from '@/js/config/timestamp-tsa';
+import type { ClassicPreset } from 'rete';
 
 // Mock external dependencies before importing the node
 vi.mock('rete', () => ({
@@ -38,11 +39,15 @@ vi.mock('@/js/workflow/sockets', () => ({
   pdfSocket: {},
 }));
 
+vi.mock('@/js/i18n/i18n', () => ({ t: (key: string) => key }));
+
 vi.mock('@/js/workflow/nodes/base-node', () => ({
   BaseWorkflowNode: class {
     addInput() {}
     addOutput() {}
-    addControl() {}
+    addControl(key: string, control: unknown) {
+      this.controls[key] = control;
+    }
     controls: Record<string, unknown> = {};
     sanitizeControlValue(key: string, value: unknown): unknown {
       const control = this.controls[key];
@@ -120,10 +125,13 @@ describe('TimestampNode', () => {
     expect(presets.length).toBeGreaterThan(0);
   });
 
-  it('should use the first TSA preset as default URL', () => {
+  it('should initialize the TSA control with the HTTPS default', () => {
     const node = new TimestampNode();
-    const presets = node.getTsaPresets();
-    expect(presets[0].url).toBe(TIMESTAMP_TSA_PRESETS[0].url);
+    const control = node.controls[
+      'tsaUrl'
+    ] as ClassicPreset.InputControl<'text'>;
+    expect(control.value).toBe(TIMESTAMP_TSA_PRESETS[0].url);
+    expect(new URL(control.value).protocol).toBe('https:');
   });
 
   it('should call timestampPdf with correct TSA URL via data()', async () => {
@@ -139,10 +147,63 @@ describe('TimestampNode', () => {
 
     await node.data({ pdf: mockInput });
 
-    expect(timestampPdf).toHaveBeenCalledWith(
+    const control = node.controls[
+      'tsaUrl'
+    ] as ClassicPreset.InputControl<'text'>;
+    expect(new URL(control.value).protocol).toBe('https:');
+    expect(timestampPdf).toHaveBeenCalledExactlyOnceWith(
       mockInput[0].bytes,
-      TIMESTAMP_TSA_PRESETS[0].url
+      control.value
     );
+  });
+
+  it.each(['absent', 'empty', 'invalid import'])(
+    'should use the HTTPS default for an %s TSA control',
+    async (scenario) => {
+      const node = new TimestampNode();
+      const control = node.controls[
+        'tsaUrl'
+      ] as ClassicPreset.InputControl<'text'>;
+      if (scenario === 'absent') {
+        delete node.controls['tsaUrl'];
+      } else {
+        control.value =
+          scenario === 'empty'
+            ? ''
+            : (node.sanitizeControlValue(
+                'tsaUrl',
+                'https://attacker.example.com/steal-tsr'
+              ) as string);
+      }
+      const bytes = new Uint8Array([1, 2, 3]);
+      await node.data({
+        pdf: [
+          { type: 'pdf', document: {} as never, bytes, filename: 'test.pdf' },
+        ],
+      });
+      expect(new URL(TIMESTAMP_TSA_PRESETS[0].url).protocol).toBe('https:');
+      expect(timestampPdf).toHaveBeenCalledExactlyOnceWith(
+        bytes,
+        TIMESTAMP_TSA_PRESETS[0].url
+      );
+    }
+  );
+
+  it('should preserve and use an explicitly imported HTTP provider', async () => {
+    const node = new TimestampNode();
+    const control = node.controls[
+      'tsaUrl'
+    ] as ClassicPreset.InputControl<'text'>;
+    const explicitUrl = 'http://timestamp.digicert.com';
+    control.value = node.sanitizeControlValue('tsaUrl', explicitUrl) as string;
+    expect(control.value).toBe(explicitUrl);
+    const bytes = new Uint8Array([1, 2, 3]);
+    await node.data({
+      pdf: [
+        { type: 'pdf', document: {} as never, bytes, filename: 'test.pdf' },
+      ],
+    });
+    expect(timestampPdf).toHaveBeenCalledExactlyOnceWith(bytes, explicitUrl);
   });
 
   it('should generate _timestamped suffix in output filename via data()', async () => {

--- a/src/tests/timestamp-pdf-page.test.ts
+++ b/src/tests/timestamp-pdf-page.test.ts
@@ -1,5 +1,26 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { TIMESTAMP_TSA_PRESETS } from '@/js/config/timestamp-tsa';
+import { readFileAsArrayBuffer, downloadFile } from '@/js/utils/helpers';
+import { timestampPdf } from '@/js/logic/digital-sign-pdf';
+
+vi.mock('lucide', () => ({ createIcons: vi.fn(), icons: {} }));
+vi.mock('@/js/ui', () => ({
+  showAlert: vi.fn(),
+  showLoader: vi.fn(),
+  hideLoader: vi.fn(),
+}));
+vi.mock('@/js/i18n/i18n', () => ({ t: (key: string) => key }));
+vi.mock('@/js/utils/helpers', () => ({
+  readFileAsArrayBuffer: vi.fn(),
+  formatBytes: vi.fn(() => '3 bytes'),
+  downloadFile: vi.fn(),
+  getPDFDocument: vi.fn(() => ({
+    promise: Promise.resolve({ numPages: 1 }),
+  })),
+}));
+vi.mock('@/js/logic/digital-sign-pdf', () => ({
+  timestampPdf: vi.fn(),
+}));
 
 /**
  * Tests for the Timestamp PDF page logic.
@@ -27,28 +48,31 @@ describe('Timestamp PDF Page', () => {
   });
 
   describe('TSA Preset Population', () => {
+    beforeEach(async () => {
+      vi.clearAllMocks();
+      vi.resetModules();
+      const addListener = vi.spyOn(document, 'addEventListener');
+      try {
+        await import('@/js/logic/timestamp-pdf-page');
+        document.dispatchEvent(new Event('DOMContentLoaded'));
+      } finally {
+        // The page module registers a new listener on every fresh import.
+        for (const [type, listener, options] of addListener.mock.calls) {
+          if (type === 'DOMContentLoaded') {
+            document.removeEventListener(type, listener, options);
+          }
+        }
+        addListener.mockRestore();
+      }
+    });
+
     it('should populate the TSA preset select element with all presets', () => {
       const select = document.getElementById('tsa-preset') as HTMLSelectElement;
-
-      for (const preset of TIMESTAMP_TSA_PRESETS) {
-        const option = document.createElement('option');
-        option.value = preset.url;
-        option.textContent = preset.label;
-        select.append(option);
-      }
-
       expect(select.options.length).toBe(TIMESTAMP_TSA_PRESETS.length);
     });
 
     it('should set option values to TSA URLs', () => {
       const select = document.getElementById('tsa-preset') as HTMLSelectElement;
-
-      for (const preset of TIMESTAMP_TSA_PRESETS) {
-        const option = document.createElement('option');
-        option.value = preset.url;
-        option.textContent = preset.label;
-        select.append(option);
-      }
 
       for (let i = 0; i < TIMESTAMP_TSA_PRESETS.length; i++) {
         expect(select.options[i].value).toBe(TIMESTAMP_TSA_PRESETS[i].url);
@@ -57,6 +81,51 @@ describe('Timestamp PDF Page', () => {
         );
       }
     });
+
+    it('should select the HTTPS default during page initialization', () => {
+      const select = document.getElementById('tsa-preset') as HTMLSelectElement;
+      expect(select.value).toBe(TIMESTAMP_TSA_PRESETS[0].url);
+      expect(new URL(select.value).protocol).toBe('https:');
+    });
+
+    it.each([undefined, 'http://timestamp.digicert.com'])(
+      'should timestamp an uploaded PDF with the default or explicit selection (%s)',
+      async (explicitUrl) => {
+        const pdfBytes = new Uint8Array([1, 2, 3]);
+        vi.mocked(readFileAsArrayBuffer).mockResolvedValueOnce(pdfBytes.buffer);
+        vi.mocked(timestampPdf).mockResolvedValueOnce(
+          new Uint8Array([4, 5, 6])
+        );
+        const select = document.getElementById(
+          'tsa-preset'
+        ) as HTMLSelectElement;
+        if (explicitUrl) select.value = explicitUrl;
+        const selectedUrl = select.value;
+        if (!explicitUrl) expect(new URL(selectedUrl).protocol).toBe('https:');
+
+        const fileInput = document.getElementById(
+          'file-input'
+        ) as HTMLInputElement;
+        const file = new File([pdfBytes], 'document.pdf', {
+          type: 'application/pdf',
+        });
+        Object.defineProperty(fileInput, 'files', { value: [file] });
+        fileInput.dispatchEvent(new Event('change'));
+
+        const processBtn = document.getElementById(
+          'process-btn'
+        ) as HTMLButtonElement;
+        await vi.waitFor(() => expect(processBtn.disabled).toBe(false));
+        processBtn.click();
+
+        await vi.waitFor(() => expect(downloadFile).toHaveBeenCalledOnce());
+        expect(timestampPdf).toHaveBeenCalledExactlyOnceWith(
+          pdfBytes,
+          selectedUrl
+        );
+        expect(processBtn.disabled).toBe(true);
+      }
+    );
   });
 
   describe('File Validation', () => {

--- a/src/tests/timestamp-tsa.test.ts
+++ b/src/tests/timestamp-tsa.test.ts
@@ -37,10 +37,20 @@ describe('Timestamp TSA Presets', () => {
     }
   });
 
-  it('should include well-known TSA providers', () => {
-    const labels = TIMESTAMP_TSA_PRESETS.map((p) => p.label);
-    expect(labels).toContain('DigiCert');
-    expect(labels).toContain('Sectigo');
+  it('should default to an allowed HTTPS authority for unproxied deployments', () => {
+    const defaultUrl = TIMESTAMP_TSA_PRESETS[0].url;
+    expect(new URL(defaultUrl).protocol).toBe('https:');
+    expect(isAllowedTsaUrl(defaultUrl)).toBe(true);
+  });
+
+  it('should retain every provider URL and the remaining relative order', () => {
+    expect(TIMESTAMP_TSA_PRESETS).toEqual([
+      { label: 'FreeTSA', url: 'https://freetsa.org/tsr' },
+      { label: 'DigiCert', url: 'http://timestamp.digicert.com' },
+      { label: 'Sectigo', url: 'http://timestamp.sectigo.com' },
+      { label: 'SSL.com', url: 'http://ts.ssl.com' },
+      { label: 'MeSign', url: 'http://tsa.mesign.com' },
+    ]);
   });
 
   it('should satisfy the TimestampTsaPreset interface', () => {


### PR DESCRIPTION
### Description

Move the existing FreeTSA HTTPS entry to the front of `TIMESTAMP_TSA_PRESETS`, documenting that the first entry is the default and must work with the HTTPS transport requirement of unproxied deployments. Retain the existing provider URLs and remaining relative order; do not invent HTTPS variants for HTTP-only providers or switch authorities after a user explicitly chooses one. Existing page initialization and workflow construction, fallback, and import sanitization already consume the shared array, so this configuration change reaches both production execution paths without new helpers or call-site edits.

The reporter cannot timestamp a PDF on an HTTPS deployment of BentoPDF 2.8.6 because the default DigiCert endpoint uses HTTP and the application rejects that mixed-content request without a configured proxy. A second human confirms the same error. The current clone already includes `https://freetsa.org/tsr`, so the report's statement that every endpoint is HTTP is no longer accurate, but DigiCert remains the first preset and therefore the default. Both the standalone page and workflow node inherit that default, preserving the reported failure on their ordinary upload-and-process path.

Fixes #777

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### 🧪 How Has This Been Tested?

Shared configuration: the default uses `https:` and remains an allowed built-in authority; retain coverage for all existing providers, unique URLs, and rejected untrusted hosts. Assertions should establish the transport requirement, not merely compare the array to itself.
Standalone page: build the existing DOM fixture, load the actual page module with external dependencies mocked, dispatch `DOMContentLoaded` once, and assert the real select defaults to the HTTPS endpoint while retaining all providers. Drive upload/process with mocked PDF loading and signing, and assert `timestampPdf()` receives the selected default. Avoid accumulating initialization listeners between tests.
Workflow: instantiate the actual node with a control-retaining mock, assert its initial TSA control is HTTPS, execute `data()` with sample PDF bytes, and assert the signing call uses that control. Invalid imported URLs and absent/empty controls must fall back to the same HTTPS default; a valid explicitly saved HTTP provider must remain unchanged.
Signing transport: with an HTTPS page origin and an empty proxy configuration, pass the real default into `timestampPdf()` and verify the mocked signer receives its unchanged HTTPS URL and returns the signed bytes. This test must fail on the current HTTP default.
Compatibility and errors: explicit HTTP provider selection on HTTPS without a proxy still fails before signing; with a configured HTTPS proxy, the provider URL is encoded into the existing proxy request. Explicit HTTP providers remain usable from an HTTP origin, and signer failures still propagate. Restore globals, environment stubs, and mock state so test order does not determine results.
Implementation validation: run `npm run test:run -- src/tests/timestamp-tsa.test.ts src/tests/timestamp-pdf-page.test.ts src/tests/timestamp-node.test.ts src/tests/digital-sign-pdf.test.ts` using installed dependencies. Run the available local TypeScript check and lint on changed TypeScript files. Tests must mock TSA traffic and make no external requests; a mocked signer verifies application routing, not a valid RFC 3161 response.

### Checklist:

- [x] I have signed the [Contributor License Agreement (CLA)](ICLA.md) or my organization has signed the [Corporate CLA](CCLA.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FreeTSA is now the default timestamp authority.
  * The default timestamp service uses HTTPS and supports direct connections on secure pages.
  * Imported timestamp settings now fall back to the secure default when missing, empty, or invalid.

* **Bug Fixes**
  * Prevented signing attempts when secure pages are configured with insecure timestamp services.

* **Tests**
  * Expanded coverage for timestamp provider ordering, secure defaults, proxy behavior, and PDF signing flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->